### PR TITLE
Enable auto-generation of documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+from os.path import abspath
+from sys import path
+
+project = 'python-sdbus-modemmanager'
+author = 'zhanglongqi'
+source_suffix = '.rst'
+extensions = ['sdbus.autodoc']
+
+autoclass_content = 'both'
+autodoc_typehints = 'description'
+autodoc_member_order = 'bysource'
+
+path.insert(0, abspath('..'))

--- a/docs/enums.rst
+++ b/docs/enums.rst
@@ -1,0 +1,20 @@
+Enums
+=====
+
+.. autoclass:: sdbus_block.modemmanager.MMModemState
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMModemMode
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMModemPowerState
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMCallDirection
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMCallState
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMCallStateReason
+    :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,21 @@
+ModemManager binds for python-sdbus
+===================================
+
+This package contains python-sdbus for D-Bus interface
+of `ModemManager <https://modemmanager.org>`_.
+
+.. note::
+    See `upstream documentation for ModemManager D-Bus API
+    <https://www.freedesktop.org/software/ModemManager/doc/latest/ModemManager/ref-dbus.html>`_
+    for more detailed documentation.
+
+.. toctree::
+    :maxdepth: 3
+    :caption: Contents:
+
+    objects
+    interfaces
+    enums
+
+See `python-sdbus <https://github.com/igo95862/python-sdbus>`_ homepage if you are
+unfamiliar with python-sdbus.

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -1,0 +1,35 @@
+Interfaces
+==========
+
+.. autoclass:: sdbus_block.modemmanager.MMInterface
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMModemsInterface
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMModemInterface
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMModemMessagingInterface
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMModemSimpleInterface
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMModemSingalInterface
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMModemVoiceInterface
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMSimInterface
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMSmsInterface
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMBearerInterface
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMCallInterface
+    :members:

--- a/docs/objects.rst
+++ b/docs/objects.rst
@@ -1,0 +1,35 @@
+ModemManager Objects
+====================
+
+.. autoclass:: sdbus_block.modemmanager.MM
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMModem
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMModems
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMModemMessaging
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMModemSignal
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMModemSimple
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMModemVoice
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMSim
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMSms
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMBearer
+    :members:
+
+.. autoclass:: sdbus_block.modemmanager.MMCall
+    :members:

--- a/sdbus_block/modemmanager/__init__.py
+++ b/sdbus_block/modemmanager/__init__.py
@@ -1,8 +1,39 @@
 from __future__ import annotations
 
-from .objects import MM, MMBearer, MMCall, MMModem, MMModems, MMModemMessaging, MMModemSignal, MMModemSimple, MMSim, MMSms
+from .enums import MMModemState, MMModemMode, MMModemPowerState, MMCallDirection, MMCallState, MMCallStateReason
+from .interfaces_bearer import MMBearerInterface
+from .interfaces_call import MMCallInterface
+from .interfaces_modem import MMModemInterface, MMModemMessagingInterface, MMModemSimpleInterface, MMModemSingalInterface, MMModemsInterface, MMModemVoiceInterface
+from .interfaces_root import MMInterface
+from .interfaces_sim import MMSimInterface
+from .interfaces_sms import MMSmsInterface
+from .objects import MM, MMBearer, MMCall, MMModem, MMModems, MMModemMessaging, MMModemSignal, MMModemSimple, MMModemVoice, MMSim, MMSms
 
 __all__ = (
+	# .enums
+	'MMModemState',
+	'MMModemMode',
+	'MMModemPowerState',
+	'MMCallDirection',
+	'MMCallState',
+	'MMCallStateReason',
+	# .interfaces_bearer
+	' MMBearerInterface',
+	# .interfaces_call
+	'MMCallInterface',
+	# .interfaces_modem
+	'MMModemInterface',
+	'MMModemMessagingInterface',
+	'MMModemSimpleInterface',
+	'MMModemSingalInterface',
+	'MMModemsInterface',
+	'MMModemVoiceInterface',
+	# .interfaces_root
+	'MMInterface',
+	# .interfaces_sim
+	'MMSimInterface',
+	# .interfaces_sms
+	'MMSmsInterface',
 	# .objects
 	'MM',
 	'MMModems',
@@ -10,6 +41,7 @@ __all__ = (
 	'MMModemMessaging',
 	'MMModemSimple',
 	'MMModemSignal',
+	'MMModemVoice',
 	'MMSim',
 	'MMSms',
 	'MMBearer',

--- a/sdbus_block/modemmanager/enums.py
+++ b/sdbus_block/modemmanager/enums.py
@@ -3,22 +3,20 @@ from enum import Enum, IntEnum, IntFlag
 
 class MMModemState(IntEnum):
 	"""Enumeration of possible modem states.
-	/*< underscore_name=mm_modem_state >*/
-	* MMModemState:
-	* @MM_MODEM_STATE_FAILED: The modem is unusable.
-	* @MM_MODEM_STATE_UNKNOWN: State unknown or not reportable.
-	* @MM_MODEM_STATE_INITIALIZING: The modem is currently being initialized.
-	* @MM_MODEM_STATE_LOCKED: The modem needs to be unlocked.
-	* @MM_MODEM_STATE_DISABLED: The modem is not enabled and is powered down.
-	* @MM_MODEM_STATE_DISABLING: The modem is currently transitioning to the @MM_MODEM_STATE_DISABLED state.
-	* @MM_MODEM_STATE_ENABLING: The modem is currently transitioning to the @MM_MODEM_STATE_ENABLED state.
-	* @MM_MODEM_STATE_ENABLED: The modem is enabled and powered on but not registered with a network provider and not available for data connections.
-	* @MM_MODEM_STATE_SEARCHING: The modem is searching for a network provider to register with.
-	* @MM_MODEM_STATE_REGISTERED: The modem is registered with a network provider, and data connections and messaging may be available for use.
-	* @MM_MODEM_STATE_DISCONNECTING: The modem is disconnecting and deactivating the last active packet data bearer. This state will not be entered if more than one packet data bearer is active and one of the active bearers is deactivated.
-	* @MM_MODEM_STATE_CONNECTING: The modem is activating and connecting the first packet data bearer. Subsequent bearer activations when another bearer is already active do not cause this state to be entered.
-	* @MM_MODEM_STATE_CONNECTED: One or more packet data bearers is active and connected.
-	*
+
+	* MM_MODEM_STATE_FAILED: The modem is unusable.
+	* MM_MODEM_STATE_UNKNOWN: State unknown or not reportable.
+	* MM_MODEM_STATE_INITIALIZING: The modem is currently being initialized.
+	* MM_MODEM_STATE_LOCKED: The modem needs to be unlocked.
+	* MM_MODEM_STATE_DISABLED: The modem is not enabled and is powered down.
+	* MM_MODEM_STATE_DISABLING: The modem is currently transitioning to the MM_MODEM_STATE_DISABLED state.
+	* MM_MODEM_STATE_ENABLING: The modem is currently transitioning to the MM_MODEM_STATE_ENABLED state.
+	* MM_MODEM_STATE_ENABLED: The modem is enabled and powered on but not registered with a network provider and not available for data connections.
+	* MM_MODEM_STATE_SEARCHING: The modem is searching for a network provider to register with.
+	* MM_MODEM_STATE_REGISTERED: The modem is registered with a network provider, and data connections and messaging may be available for use.
+	* MM_MODEM_STATE_DISCONNECTING: The modem is disconnecting and deactivating the last active packet data bearer. This state will not be entered if more than one packet data bearer is active and one of the active bearers is deactivated.
+	* MM_MODEM_STATE_CONNECTING: The modem is activating and connecting the first packet data bearer. Subsequent bearer activations when another bearer is already active do not cause this state to be entered.
+	* MM_MODEM_STATE_CONNECTED: One or more packet data bearers is active and connected.
 	"""
 	MM_MODEM_STATE_FAILED = -1,
 	MM_MODEM_STATE_UNKNOWN = 0,
@@ -36,16 +34,15 @@ class MMModemState(IntEnum):
 
 
 class MMModemMode(IntEnum):
-	"""
-	/*< underscore_name=mm_modem_mode >*/
+	"""Bitfield to indicate which access modes are supported, allowed or preferred in a given device.
 
-	* @MM_MODEM_MODE_NONE: None.
-	* @MM_MODEM_MODE_CS: CSD, GSM, and other circuit-switched technologies.
-	* @MM_MODEM_MODE_2G: GPRS, EDGE.
-	* @MM_MODEM_MODE_3G: UMTS, HSxPA.
-	* @MM_MODEM_MODE_4G: LTE.
-	* @MM_MODEM_MODE_5G: 5GNR. Since 1.14.
-	* @MM_MODEM_MODE_ANY: Any mode can be used (only this value allowed for POTS modems).
+	* MM_MODEM_MODE_NONE: None.
+	* MM_MODEM_MODE_CS: CSD, GSM, and other circuit-switched technologies.
+	* MM_MODEM_MODE_2G: GPRS, EDGE.
+	* MM_MODEM_MODE_3G: UMTS, HSxPA.
+	* MM_MODEM_MODE_4G: LTE.
+	* MM_MODEM_MODE_5G: 5GNR. Since 1.14.
+	* MM_MODEM_MODE_ANY: Any mode can be used (only this value allowed for POTS modems).
 	"""
 	MM_MODEM_MODE_NONE = 0,
 	MM_MODEM_MODE_CS = 1 << 0,
@@ -56,16 +53,12 @@ class MMModemMode(IntEnum):
 
 
 class MMModemPowerState(IntEnum):
-	"""_summary_
-	/*< underscore_name=mm_modem_power_state >*/
-	Power state of the modem.
+	"""Power state of the modem.
 
-	MM_MODEM_POWER_STATE_UNKNOWN	Unknown power state.
-	MM_MODEM_POWER_STATE_OFF		Off.
-	MM_MODEM_POWER_STATE_LOW		Low-power mode.
-	MM_MODEM_POWER_STATE_ON			Full power mode.
-	Args:
-		IntEnum (_type_): _description_
+	* MM_MODEM_POWER_STATE_UNKNOWN		Unknown power state.
+	* MM_MODEM_POWER_STATE_OFF		Off.
+	* MM_MODEM_POWER_STATE_LOW		Low-power mode.
+	* MM_MODEM_POWER_STATE_ON		Full power mode.
 	"""
 	MM_MODEM_POWER_STATE_UNKNOWN = 0,
 	MM_MODEM_POWER_STATE_OFF = 1,
@@ -74,39 +67,29 @@ class MMModemPowerState(IntEnum):
 
 
 class MMCallDirection(IntEnum):
-	"""_summary_
-	/*< underscore_name=mm_call_direction >*/
-	Direction of the call.
+	"""Direction of the call.
 
-	MM_CALL_DIRECTION_UNKNOWN	Unknown.
-	MM_CALL_DIRECTION_INCOMING	Call from network.
-	MM_CALL_DIRECTION_OUTGOING	Call to network.
-	Args:
-		IntEnum (_type_): _description_
+	* MM_CALL_DIRECTION_UNKNOWN	Unknown.
+	* MM_CALL_DIRECTION_INCOMING	Call from network.
+	* MM_CALL_DIRECTION_OUTGOING	Call to network.
 	"""
-
 	MM_CALL_DIRECTION_UNKNOWN = 0,
 	MM_CALL_DIRECTION_INCOMING = 1,
 	MM_CALL_DIRECTION_OUTGOING = 2
 
 
 class MMCallState(IntEnum):
-	"""_summary_
-	/*< underscore_name=mm_call_state >*/
-	State of Call.
+	"""State of Call.
 
-	MM_CALL_STATE_UNKNOWN			Default state for a new outgoing call.
-	MM_CALL_STATE_DIALING			Outgoing call started. Wait for free channel.
-	MM_CALL_STATE_RINGING_OUT		Outgoing call attached to GSM network, waiting for an answer.
-	MM_CALL_STATE_RINGING_IN		Incoming call is waiting for an answer.
-	MM_CALL_STATE_ACTIVE			Call is active between two peers.
-	MM_CALL_STATE_HELD				Held call (by +CHLD AT command).
-	MM_CALL_STATE_WAITING			Waiting call (by +CCWA AT command).
-	MM_CALL_STATE_TERMINATED		Call is terminated.
-	Args:
-		IntEnum (_type_): _description_
+	* MM_CALL_STATE_UNKNOWN			Default state for a new outgoing call.
+	* MM_CALL_STATE_DIALING			Outgoing call started. Wait for free channel.
+	* MM_CALL_STATE_RINGING_OUT		Outgoing call attached to GSM network, waiting for an answer.
+	* MM_CALL_STATE_RINGING_IN		Incoming call is waiting for an answer.
+	* MM_CALL_STATE_ACTIVE			Call is active between two peers.
+	* MM_CALL_STATE_HELD			Held call (by +CHLD AT command).
+	* MM_CALL_STATE_WAITING			Waiting call (by +CCWA AT command).
+	* MM_CALL_STATE_TERMINATED		Call is terminated.
 	"""
-
 	MM_CALL_STATE_UNKNOWN = 0,
 	MM_CALL_STATE_DIALING = 1,
 	MM_CALL_STATE_RINGING_OUT = 2,
@@ -118,24 +101,19 @@ class MMCallState(IntEnum):
 
 
 class MMCallStateReason(IntEnum):
-	"""_summary_
-	/*< underscore_name=mm_call_state_reason >*/
-	Reason for the state change in the call.
+	"""Reason for the state change in the call.
 
-	MM_CALL_STATE_REASON_UNKNOWN			Default value for a new outgoing call.
-	MM_CALL_STATE_REASON_OUTGOING_STARTED	Outgoing call is started.
-	MM_CALL_STATE_REASON_INCOMING_NEW		Received a new incoming call.
-	MM_CALL_STATE_REASON_ACCEPTED			Dialing or Ringing call is accepted.
-	MM_CALL_STATE_REASON_TERMINATED			Call is correctly terminated.
-	MM_CALL_STATE_REASON_REFUSED_OR_BUSY	Remote peer is busy or refused call.
-	MM_CALL_STATE_REASON_ERROR				Wrong number or generic network error.
-	MM_CALL_STATE_REASON_AUDIO_SETUP_FAILED	Error setting up audio channel. Since 1.10.
-	MM_CALL_STATE_REASON_TRANSFERRED		Call has been transferred. Since 1.12.
-	MM_CALL_STATE_REASON_DEFLECTED			Call has been deflected to a new number. Since 1.12.
-	Args:
-		IntEnum (_type_): _description_
+	* MM_CALL_STATE_REASON_UNKNOWN		Default value for a new outgoing call.
+	* MM_CALL_STATE_REASON_OUTGOING_STARTED	Outgoing call is started.
+	* MM_CALL_STATE_REASON_INCOMING_NEW	Received a new incoming call.
+	* MM_CALL_STATE_REASON_ACCEPTED		Dialing or Ringing call is accepted.
+	* MM_CALL_STATE_REASON_TERMINATED	Call is correctly terminated.
+	* MM_CALL_STATE_REASON_REFUSED_OR_BUSY	Remote peer is busy or refused call.
+	* MM_CALL_STATE_REASON_ERROR		Wrong number or generic network error.
+	* MM_CALL_STATE_REASON_AUDIO_SETUP_FAILED	Error setting up audio channel. Since 1.10.
+	* MM_CALL_STATE_REASON_TRANSFERRED	Call has been transferred. Since 1.12.
+	* MM_CALL_STATE_REASON_DEFLECTED	Call has been deflected to a new number. Since 1.12.
 	"""
-
 	MM_CALL_STATE_REASON_UNKNOWN = 0,
 	MM_CALL_STATE_REASON_OUTGOING_STARTED = 1,
 	MM_CALL_STATE_REASON_INCOMING_NEW = 2,

--- a/sdbus_block/modemmanager/interfaces_bearer.py
+++ b/sdbus_block/modemmanager/interfaces_bearer.py
@@ -9,25 +9,22 @@ class MMBearerInterface(DbusInterfaceCommon, interface_name='org.freedesktop.Mod
 	@dbus_method()
 	def connect(self) -> None:
 		"""
-        Requests activation of a packet data connection with the network using this bearer's properties. 
-		Upon successful activation, the modem can send and receive packet data and, depending on the addressing 
-		capability of the modem, a connection manager may need to start PPP, perform DHCP, or assign the IP address 
-		returned by the modem to the data interface. Upon successful return, the "Ip4Config" and/or "Ip6Config" 
-		properties become valid and may contain IP configuration information for the data interface associated with 
+		Requests activation of a packet data connection with the network using this bearer's properties.
+		Upon successful activation, the modem can send and receive packet data and, depending on the addressing
+		capability of the modem, a connection manager may need to start PPP, perform DHCP, or assign the IP address
+		returned by the modem to the data interface. Upon successful return, the "Ip4Config" and/or "Ip6Config"
+		properties become valid and may contain IP configuration information for the data interface associated with
 		this bearer.
-        Raises:
-            NotImplementedError: _description_
-        """
+		"""
 		raise NotImplementedError
 
 	@dbus_method()
 	def disconnect(self) -> None:
 		"""
-        Disconnect and deactivate this packet data connection.
+		Disconnect and deactivate this packet data connection.
+		
 		Any ongoing data session will be terminated and IP addresses become invalid when this method is called.
-        Raises:
-            NotImplementedError: _description_
-        """
+		"""
 		raise NotImplementedError
 
 	@dbus_property('s')
@@ -35,12 +32,12 @@ class MMBearerInterface(DbusInterfaceCommon, interface_name='org.freedesktop.Mod
 		"""
 		The operating system name for the network data interface that provides packet data using this bearer.
 
-		Connection managers must configure this interface depending on the IP "method" given by the "Ip4Config" or 
+		Connection managers must configure this interface depending on the IP "method" given by the "Ip4Config" or
 		"Ip6Config" properties set by bearer activation.
 
-		If MM_BEARER_IP_METHOD_STATIC or MM_BEARER_IP_METHOD_DHCP methods are given, the interface will be an 
-		ethernet-style interface suitable for DHCP or setting static IP configuration on, while if the 
-		MM_BEARER_IP_METHOD_PPP method is given, the interface will be a serial TTY which must then have PPP run 
+		If MM_BEARER_IP_METHOD_STATIC or MM_BEARER_IP_METHOD_DHCP methods are given, the interface will be an
+		ethernet-style interface suitable for DHCP or setting static IP configuration on, while if the
+		MM_BEARER_IP_METHOD_PPP method is given, the interface will be a serial TTY which must then have PPP run
 		over it.
 		"""
 		raise NotImplementedError
@@ -48,7 +45,7 @@ class MMBearerInterface(DbusInterfaceCommon, interface_name='org.freedesktop.Mod
 	@dbus_property('b')
 	def connected(self) -> bool:
 		"""
-		Indicates whether or not the bearer is connected and thus whether packet data communication using this bearer 
+		Indicates whether or not the bearer is connected and thus whether packet data communication using this bearer
 		is possible.
 		"""
 		raise NotImplementedError
@@ -56,7 +53,7 @@ class MMBearerInterface(DbusInterfaceCommon, interface_name='org.freedesktop.Mod
 	@dbus_property('b')
 	def suspended(self) -> bool:
 		"""
-		In some devices, packet data service will be suspended while the device is handling other communication, like 
+		In some devices, packet data service will be suspended while the device is handling other communication, like
 		a voice call. If packet data service is suspended (but not deactivated) this property will be TRUE.
 		"""
 		raise NotImplementedError
@@ -65,39 +62,32 @@ class MMBearerInterface(DbusInterfaceCommon, interface_name='org.freedesktop.Mod
 	def ip4_config(self) -> Tuple[str]:
 		"""
 		If the bearer was configured for IPv4 addressing, upon activation this property contains the addressing details for assignment to the data interface.
-
-			Mandatory items include:
-
-			"method"
+		
+		Mandatory items include:
+		
+		"method"
 			A MMBearerIpMethod, given as an unsigned integer value (signature "u").
 			If the bearer specifies configuration via PPP or DHCP, only the "method" item will be present.
 			Additional items which are only applicable when using the MM_BEARER_IP_METHOD_STATIC method are:
-
-			"address"
+		"address"
 			IP address, given as a string value (signature "s").
-			
-			"prefix"
+		"prefix"
 			Numeric CIDR network prefix (ie, 24, 32, etc), given as an unsigned integer value (signature "u").
-			
-			"dns1"
+		"dns1"
 			IP address of the first DNS server, given as a string value (signature "s").
-			
-			"dns2"
+		"dns2"
 			IP address of the second DNS server, given as a string value (signature "s").
-			
-			"dns3"
+		"dns3"
 			IP address of the third DNS server, given as a string value (signature "s").
-			
-			"gateway"
+		"gateway"
 			IP address of the default gateway, given as a string value (signature "s").
 			This property may also include the following items when such information is available:
-
-			"mtu"
+		"mtu"
 			Maximum transmission unit (MTU), given as an unsigned integer value (signature "u").
-
 		"""
 		raise NotImplementedError
 
 	@dbus_property(property_signature='a{sv}')
 	def stats(self) -> Dict[str, Tuple[str, Any]]:
+		"""If the modem supports it, this property will show statistics associated to the bearer."""
 		raise NotImplementedError

--- a/sdbus_block/modemmanager/interfaces_call.py
+++ b/sdbus_block/modemmanager/interfaces_call.py
@@ -7,27 +7,19 @@ class MMCallInterface(DbusInterfaceCommon, interface_name='org.freedesktop.Modem
 
 	@dbus_method()
 	def start(self) -> None:
-		"""
-		If the outgoing call has not yet been started, start it.
-		"""
+		"""If the outgoing call has not yet been started, start it."""
 		raise NotImplementedError
 
 	@dbus_method()
 	def accept(self) -> None:
-		"""
-		Accept incoming call (answer).
-		"""
+		"""Accept incoming call (answer)."""
 		raise NotImplementedError
 
 	@dbus_method(input_signature='s')
 	def deflect(self, number: str) -> None:
 		"""Deflect an incoming or waiting call to a new number.
 
-		IN s number:
-			new number where the call will be deflected.
-
-		Args:
-			number (str): _description_
+		:param number: new number where the call will be deflected.
 		"""
 		raise NotImplementedError
 
@@ -41,75 +33,53 @@ class MMCallInterface(DbusInterfaceCommon, interface_name='org.freedesktop.Modem
 	@dbus_method()
 	def leave_multiparty(self) -> None:
 		"""
-		If this call is part of an ongoing multiparty call, detach it from the multiparty call, put the multiparty call on hold, and activate this one alone.
+		If this call is part of an ongoing multiparty call, detach it from the multiparty call,
+		put the multiparty call on hold, and activate this one alone.
 		"""
 		raise NotImplementedError
 
 	@dbus_method()
 	def hangup(self) -> None:
-		"""
-		Hangup the active call.
-		"""
+		"""Hangup the active call."""
 		raise NotImplementedError
 
 	@dbus_method(input_signature='s')
 	def send_dtmf(self, dtmf: str) -> None:
-		"""Send a DTMF tone (Dual Tone Multi-Frequency) (only on supported modem).
+		"""
+		Send a DTMF tone (Dual Tone Multi-Frequency) (only on supported modem).
 
-		IN s dtmf:
-			DTMF tone identifier [0-9A-D*#].
-
-		Args:
-			dtmf (str): _description_
+		:param dtmf: DTMF tone identifier [0-9A-D*#].
 		"""
 		raise NotImplementedError
 
 	@dbus_property('i')
 	def state(self) -> int:
-		"""A MMCallState value, describing the state of the call.
-		Returns:
-			int: _description_
-		"""
+		"""A MMCallState value, describing the state of the call."""
 		raise NotImplementedError
 
 	@dbus_property('i')
 	def state_reason(self) -> int:
-		"""A MMCallStateReason value, describing why the state is changed.
-		Returns:
-			int: _description_
-		"""
+		"""A MMCallStateReason value, describing why the state is changed."""
 		raise NotImplementedError
 
 	@dbus_property('i')
 	def direction(self) -> int:
-		"""A MMCallDirection value, describing the direction of the call.
-		Returns:
-			int: _description_
-		"""
+		"""A MMCallDirection value, describing the direction of the call."""
 		raise NotImplementedError
 
 	@dbus_property('s')
 	def number(self) -> str:
-		"""The remote phone number.
-		Returns:
-			str: _description_
-		"""
+		"""The remote phone number."""
 		raise NotImplementedError
 
 	@dbus_property('b')
 	def multiparty(self) -> bool:
-		"""Whether the call is currently part of a multiparty conference call.
-		Returns:
-			bool: _description_
-		"""
+		"""Whether the call is currently part of a multiparty conference call."""
 		raise NotImplementedError
 
 	@dbus_property('s')
 	def audio_port(self) -> str:
-		"""Name of the kernel device that provides the audio (if call audio is routed via the host).
-		Returns:
-			str: _description_
-		"""
+		"""Name of the kernel device that provides the audio (if call audio is routed via the host)."""
 		raise NotImplementedError
 
 	@dbus_property('a{sv}')

--- a/sdbus_block/modemmanager/interfaces_modem.py
+++ b/sdbus_block/modemmanager/interfaces_modem.py
@@ -32,25 +32,18 @@ class MMModemInterface(DbusInterfaceCommon, interface_name='org.freedesktop.Mode
 	@dbus_method(input_signature='b')
 	def enable(self, enable: bool = True) -> None:
 		"""
-        Enable or disable the modem.
+		Enable or disable the modem.
 
 		When enabled, the modem's radio is powered on and data sessions, voice calls, location services, and Short Message Service may be available.
-
 		When disabled, the modem enters low-power state and no network-related operations are available.
 
-		IN b enable: TRUE to enable the modem and FALSE to disable it.
-
-        Raises:
-            NotImplementedError: _description_
-        """
+		:param enable: True to enable the modem and False to disable it.
+		"""
 		raise NotImplementedError
 
 	@dbus_property('o', property_name='Sim')
 	def sim_object_path(self) -> str:
-		"""The path of the SIM object available in this device, if any.
-		Returns:
-			str: The path of the SIM object available in this device, if any.
-		"""
+		"""The path of the SIM object available in this device, if any."""
 		raise NotImplementedError
 
 	@dbus_property('o', property_name='Bearers')
@@ -64,30 +57,22 @@ class MMModemInterface(DbusInterfaceCommon, interface_name='org.freedesktop.Mode
 
 	@dbus_property('s')
 	def manufacturer(self) -> str:
-		"""
-		The equipment manufacturer, as reported by the modem.
-		"""
+		"""The equipment manufacturer, as reported by the modem."""
 		raise NotImplementedError
 
 	@dbus_property('s')
 	def model(self) -> str:
-		"""
-		The equipment model, as reported by the modem.
-		"""
+		"""The equipment model, as reported by the modem."""
 		raise NotImplementedError
 
 	@dbus_property('s', property_name='Revision')
 	def revision(self) -> str:
-		"""
-		The revision identification of the software, as reported by the modem.
-		"""
+		"""The revision identification of the software, as reported by the modem."""
 		raise NotImplementedError
 
 	@dbus_property('s')
 	def hardware_revision(self) -> str:
-		"""
-		The revision identification of the hardware, as reported by the modem.
-		"""
+		"""The revision identification of the hardware, as reported by the modem."""
 		raise NotImplementedError
 
 	@dbus_property('s')
@@ -103,16 +88,14 @@ class MMModemInterface(DbusInterfaceCommon, interface_name='org.freedesktop.Mode
 
 	@dbus_property('s')
 	def primary_port(self) -> str:
-		"""
-		The name of the primary port using to control the modem.
-		"""
+		"""The name of the primary port using to control the modem."""
 		raise NotImplementedError
 
 	@dbus_property('s')
 	def equipment_identifier(self) -> str:
 		"""
 		The identity of the device.
-		This will be the IMEI number for GSM devices and the hex-format ESN/MEID for CDMA devices.		
+		This will be the IMEI number for GSM devices and the hex-format ESN/MEID for CDMA devices.
 		"""
 		raise NotImplementedError
 
@@ -124,7 +107,7 @@ class MMModemInterface(DbusInterfaceCommon, interface_name='org.freedesktop.Mode
 	def state(self) -> int:
 		"""
 		Overall state of the modem, given as a MMModemState value.
-		If the device's state cannot be determined, MM_MODEM_STATE_UNKNOWN will be reported.	
+		If the device's state cannot be determined, MM_MODEM_STATE_UNKNOWN will be reported.
 		"""
 		raise NotImplementedError
 
@@ -135,7 +118,8 @@ class MMModemInterface(DbusInterfaceCommon, interface_name='org.freedesktop.Mode
 	@dbus_property('u')
 	def state_failed_reason(self):
 		"""
-		Error specifying why the modem is in MM_MODEM_STATE_FAILED state, given as a MMModemStateFailedReason value.
+		Error specifying why the modem is in MM_MODEM_STATE_FAILED state,
+		given as a MMModemStateFailedReason value.
 		"""
 		raise NotImplementedError
 
@@ -149,16 +133,12 @@ class MMModemInterface(DbusInterfaceCommon, interface_name='org.freedesktop.Mode
 
 	@dbus_property('as')
 	def own_numbers(self):
-		"""
-		List of numbers (e.g. MSISDN in 3GPP) being currently handled by this modem.
-		"""
+		"""List of numbers (e.g. MSISDN in 3GPP) being currently handled by this modem."""
 		raise NotImplementedError
 
 	@dbus_property('u')
 	def power_state(self):
-		"""
-		A MMModemPowerState value specifying the current power state of the modem.
-		"""
+		"""A MMModemPowerState value specifying the current power state of the modem."""
 		raise NotImplementedError
 
 	@property
@@ -208,41 +188,28 @@ class MMModemSimpleInterface(DbusInterfaceCommon, interface_name='org.freedeskto
 		Allowed key/value pairs in properties are:
 
 		"pin"
-
-		SIM-PIN unlock code, given as a string value (signature "s").
+			SIM-PIN unlock code, given as a string value (signature "s").
 		"operator-id"
-
-		ETSI MCC-MNC of a network to force registration with, given as a string value (signature "s").
+			ETSI MCC-MNC of a network to force registration with, given as a string value (signature "s").
 		"apn"
-
-		For GSM/UMTS and LTE devices the APN to use, given as a string value (signature "s").
+			For GSM/UMTS and LTE devices the APN to use, given as a string value (signature "s").
 		"ip-type"
-
-		For GSM/UMTS and LTE devices the IP addressing type to use, given as a MMBearerIpFamily value (signature "u").
+			For GSM/UMTS and LTE devices the IP addressing type to use, given as a MMBearerIpFamily value (signature "u").
 		"allowed-auth"
-
-		The authentication method to use, given as a MMBearerAllowedAuth value (signature "u"). Optional in 3GPP.
+			The authentication method to use, given as a MMBearerAllowedAuth value (signature "u"). Optional in 3GPP.
 		"user"
-
-		User name (if any) required by the network, given as a string value (signature "s"). Optional in 3GPP.
+			User name (if any) required by the network, given as a string value (signature "s"). Optional in 3GPP.
 		"password"
-
-		Password (if any) required by the network, given as a string value (signature "s"). Optional in 3GPP.
+			Password (if any) required by the network, given as a string value (signature "s"). Optional in 3GPP.
 		"number"
-
-		For POTS devices the number to dial,, given as a string value (signature "s").
+			For POTS devices the number to dial, given as a string value (signature "s").
 		"allow-roaming"
-
-		FALSE to allow only connections to home networks, given as a boolean value (signature "b").
+			False to allow only connections to home networks, given as a boolean value (signature "b").
 		"rm-protocol"
+			For CDMA devices, the protocol of the Rm interface, given as a MMModemCdmaRmProtocol value (signature "u").
 
-		For CDMA devices, the protocol of the Rm interface, given as a MMModemCdmaRmProtocol value (signature "u").
-
-		IN a{sv} properties:
-		Dictionary of properties needed to get the modem connected.
-
-		OUT o bearer:
-		On successful connect, returns the object path of the connected packet data bearer used for the connection attempt.
+		:param properties: Dictionary of properties needed to get the modem connected.
+		:returns: On successful connect, returns the object path of the connected packet data bearer used for the connection attempt.
 		"""
 		raise NotImplementedError
 
@@ -251,8 +218,7 @@ class MMModemSimpleInterface(DbusInterfaceCommon, interface_name='org.freedeskto
 		"""
 		data bearer, while if "/" (ie, no object given) this method will disconnect all active packet data bearers.
 		Disconnect an active packet data connection.
-		IN o bearer:
-			If given this method will disconnect the referenced packet
+		:param bearer: If given this method will disconnect the referenced packet
 		"""
 		raise NotImplementedError
 
@@ -262,6 +228,7 @@ class MMModemSimpleInterface(DbusInterfaceCommon, interface_name='org.freedeskto
 		Get the general modem status.
 
 		The predefined common properties returned are:
+
 		"state"
 			A MMModemState value specifying the overall state of the modem, given as an unsigned integer value (signature "u").
 		"signal-quality"
@@ -285,8 +252,7 @@ class MMModemSimpleInterface(DbusInterfaceCommon, interface_name='org.freedeskto
 		"cdma-nid"
 			The Network Identifier of the serving network, if registered in a CDMA1x network and if known. Given as an unsigned integer value (signature "u").
 		
-		OUT a{sv} properties:
-			Dictionary of properties.
+		:returns: Dictionary of properties.
 		"""
 		raise NotImplementedError
 
@@ -297,19 +263,15 @@ class MMModemSingalInterface(DbusInterfaceCommon, interface_name='org.freedeskto
 	def setup(self, rate: int):
 		"""Setup extended signal quality information retrieval.
 		
-		IN u rate:
-			refresh rate to set, in seconds. 0 to disable retrieval.
-		
-		Args:
-			rate (int): _description_
+		:param rate: Refresh rate to set, in seconds. 0 to disable retrieval.
 		"""
 		raise NotImplementedError
 
 	@dbus_property('u')
 	def rate(self) -> int:
-		"""Refresh rate for the extended signal quality information updates, in seconds. A value of 0 disables the retrieval of the values.
-		Returns:
-			int: _description_
+		"""
+		Refresh rate for the extended signal quality information updates, in seconds.
+		A value of 0 disables the retrieval of the values.
 		"""
 		raise NotImplementedError
 	
@@ -363,11 +325,7 @@ class MMModemVoiceInterface(DbusInterfaceCommon, interface_name='org.freedesktop
 		"""
 		Retrieve all Calls.
 
-		OUT ao result:
-			The list of call object paths.
-
-		Returns:
-			list[str]: _description_
+		:returns: The list of call object paths.
 		"""
 		raise NotImplementedError
 
@@ -377,11 +335,7 @@ class MMModemVoiceInterface(DbusInterfaceCommon, interface_name='org.freedesktop
 		Delete a Call from the list of calls.
 		The call will be hangup if it is still active.
 
-		IN o path:
-			The object path of the Call to delete.
-
-		Args:
-			path (str): _description_
+		:param path: The object path of the Call to delete.
 		"""
 		raise NotImplementedError
 
@@ -391,81 +345,50 @@ class MMModemVoiceInterface(DbusInterfaceCommon, interface_name='org.freedesktop
 		Creates a new call object for a new outgoing call.
 		The 'Number' is the only expected property to set by the user.
 
-		IN a{sv} properties:
-			Call properties from the Call D-Bus interface.
-
-		OUT o path:
-			The object path of the new call object.
-
-		Args:
-			properties (dict[str, str]): Call properties from the Call D-Bus interface.
-		Returns:
-			str: The object path of the new call object.
+		:param properties: Call properties from the Call D-Bus interface.
+		:returns: The object path of the new call object.
 		"""
 		raise NotImplementedError
 
 	@dbus_method()
 	def hold_and_accept(self) -> None:
-		"""
-		Place all active calls on hold, if any, and accept the next call.
-		"""
+		"""Place all active calls on hold, if any, and accept the next call."""
 		raise NotImplementedError
 
 	@dbus_method()
 	def hangup_and_accept(self) -> None:
-		"""
-		Hangup all active calls, if any, and accept the next call.
-		"""
+		"""Hangup all active calls, if any, and accept the next call."""
 		raise NotImplementedError
 
 	@dbus_method()
 	def hangup_all(self) -> None:
-		"""
-		Hangup all active calls.
-		"""
+		"""Hangup all active calls."""
 		raise NotImplementedError
 
 	@dbus_method()
 	def transfer(self) -> None:
 		"""
-		Join the currently active and held calls together into a single multiparty call, but disconnects from them.
+		Join the currently active and held calls together into a single multiparty call,
+		but disconnects from them.
 		"""
 		raise NotImplementedError
 
 	@dbus_method(input_signature='b')
 	def call_waiting_setup(self, enable: bool) -> None:
-		"""Activates or deactivates the call waiting network service, as per 3GPP TS 22.083.
-
-		IN b enable:
-
-		Args:
-			enable (bool): _description_
-		"""
+		"""Activates or deactivates the call waiting network service, as per 3GPP TS 22.083."""
 		raise NotImplementedError
 
 	@dbus_method(result_signature='b')
 	def call_waiting_query(self) -> bool:
-		"""Queries the status of the call waiting network service, as per 3GPP TS 22.083.
-
-		OUT b status:
-
-		Returns:
-			bool: _description_
-		"""
+		"""Queries the status of the call waiting network service, as per 3GPP TS 22.083."""
 		raise NotImplementedError
 
 	@dbus_property('o', property_name='Calls')
 	def call_object_paths(self) -> List[str]:
-		"""The list of calls object paths.
-		Returns:
-			list[str]: _description_
-		"""
+		"""The list of calls object paths."""
 		raise NotImplementedError
 
 	@dbus_property('b')
 	def emergency_only(self) -> bool:
-		"""A flag indicating whether emergency calls are the only allowed ones.
-		Returns:
-			bool: _description_
-		"""
+		"""A flag indicating whether emergency calls are the only allowed ones."""
 		raise NotImplementedError

--- a/sdbus_block/modemmanager/interfaces_root.py
+++ b/sdbus_block/modemmanager/interfaces_root.py
@@ -8,22 +8,14 @@ class MMInterface(DbusInterfaceCommon, interface_name='org.freedesktop.ModemMana
 
 	@dbus_method()
 	def scan_devices(self) -> None:
-		"""
-		Start a new scan for connected modem devices.
-		Raises:
-			NotImplementedError: _description_
-		"""
+		"""Start a new scan for connected modem devices."""
 		raise NotImplementedError
 
 	@dbus_method(input_signature='s')
 	def set_logging(self, level: str) -> None:
-		"""
-		Set logging verbosity.
-		Args:
-			level (str): IN s level:	One of "ERR", "WARN", "INFO", "DEBUG".
+		"""Set logging verbosity.
 
-		Raises:
-			NotImplementedError: _description_
+		:param level: One of "ERR", "WARN", "INFO", "DEBUG".
 		"""
 		raise NotImplementedError
 

--- a/sdbus_block/modemmanager/interfaces_sim.py
+++ b/sdbus_block/modemmanager/interfaces_sim.py
@@ -7,65 +7,53 @@ class MMSimInterface(DbusInterfaceCommon, interface_name='org.freedesktop.ModemM
 	@dbus_method(input_signature='s')
 	def send_pin(self, pin: str = '') -> None:
 		"""
-        Send the PIN to unlock the SIM card.
-			IN s pin:
-			A string containing the PIN code.
-        Raises:
-            NotImplementedError: _description_
-        """
+		Send the PIN to unlock the SIM card.
+
+		:param pin: A string containing the PIN code.
+		"""
 		raise NotImplementedError
 
 	@dbus_method(input_signature='ss')
 	def send_puk(self, puk: str = '', pin: str = '') -> None:
 		"""
-        Send the PUK and a new PIN to unlock the SIM card.
-			IN s puk:
-			A string containing the PUK code.
-			IN s pin:
-			A string containing the PIN code.
-        Raises:
-            NotImplementedError: _description_
-        """
+		Send the PUK and a new PIN to unlock the SIM card.
+
+		:param puk: A string containing the PUK code.
+		:param pin: A string containing the PIN code.
+		"""
 		raise NotImplementedError
 
 	@dbus_method(input_signature='sb')
 	def enable_pin(self, pin: str = '', enable: bool = False) -> None:
 		"""
-        Enable or disable the PIN checking.
-			IN s pin:
-			A string containing the PIN code.
-			IN b enabled:
-			TRUE to enable PIN checking, FALSE otherwise.
-        Raises:
-            NotImplementedError: _description_
-        """
+		Enable or disable the PIN checking.
+
+		:param pin: A string containing the PIN code.
+		:param enabled: TRUE to enable PIN checking, FALSE otherwise.
+		"""
 		raise NotImplementedError
 
 	@dbus_method(input_signature='ss')
 	def change_pin(self, old_pin: str = '', new_pin: str = '') -> None:
 		"""
-        Change the PIN code.
-			IN s old_pin:
-			A string containing the current PIN code.
-			IN s new_pin:
-			A string containing the new PIN code.
-        Raises:
-            NotImplementedError: _description_
-        """
+		Change the PIN code.
+
+		:param old_pin: A string containing the current PIN code.
+		:param new_pin: A string containing the new PIN code.
+		"""
 		raise NotImplementedError
 
 	@dbus_property('s')
 	def sim_identifier(self) -> str:
-		"""The ICCID of the SIM card.
+		"""
+		The ICCID of the SIM card.
 		This may be available before the PIN has been entered depending on the device itself.
 		"""
 		raise NotImplementedError
 
 	@dbus_property('s')
 	def imsi(self) -> str:
-		"""
-		The IMSI of the SIM card, if any.
-		"""
+		"""The IMSI of the SIM card, if any."""
 		raise NotImplementedError
 
 	@dbus_property('s')
@@ -74,7 +62,5 @@ class MMSimInterface(DbusInterfaceCommon, interface_name='org.freedesktop.ModemM
 
 	@dbus_property('s')
 	def operator_name(self) -> str:
-		"""
-		The name of the network operator, as given by the SIM card, if known.
-		"""
+		"""The name of the network operator, as given by the SIM card, if known."""
 		raise NotImplementedError

--- a/sdbus_block/modemmanager/objects.py
+++ b/sdbus_block/modemmanager/objects.py
@@ -16,17 +16,17 @@ MODEM_MANAGER_SERVICE_NAME = 'org.freedesktop.ModemManager1'
 class MM(MMInterface):
 	"""Modem Manger main object
 
-    Implements :py:class:`ModemManagerInterface`
+	Implements :py:class:`ModemManagerInterface`
 
-    Service name ``'org.freedesktop.ModemManager1'``
-    and object path ``/org/freedesktop/ModemManager1`` is predetermined.
-    """
+	Service name ``'org.freedesktop.ModemManager1'``
+	and object path ``/org/freedesktop/ModemManager1`` is predetermined.
+	"""
 
 	def __init__(self, bus: Optional[SdBus] = None) -> None:
 		"""
-        :param bus: You probably want to set default bus to system bus \
-            or pass system bus directly.
-        """
+		:param bus: You probably want to set default bus to system bus \
+			or pass system bus directly.
+		"""
 		super().__init__(MODEM_MANAGER_SERVICE_NAME, '/org/freedesktop/ModemManager1', bus)
 
 
@@ -39,7 +39,7 @@ class MMSms(MMSmsInterface):
 	) -> None:
 		"""
 		:param bus: You probably want to set default bus to system bus \
-		or pass system bus directly.
+			or pass system bus directly.
 		"""
 		super().__init__(MODEM_MANAGER_SERVICE_NAME, object_path, bus)
 
@@ -68,9 +68,9 @@ class MMModemSignal(MMModemSingalInterface):
 
 	def __init__(self, object_path: str, bus: Optional[SdBus] = None) -> None:
 		"""
-        :param bus: You probably want to set default bus to system bus \
-            or pass system bus directly.
-        """
+		:param bus: You probably want to set default bus to system bus \
+			or pass system bus directly.
+		"""
 		super().__init__(MODEM_MANAGER_SERVICE_NAME, object_path, bus)
 
 
@@ -97,9 +97,9 @@ class MMModem(MMModemInterface):
 		bus: Optional[SdBus] = None,
 	) -> None:
 		"""
-        :param bus: You probably want to set default bus to system bus \
-            or pass system bus directly.
-        """
+		:param bus: You probably want to set default bus to system bus \
+			or pass system bus directly.
+		"""
 		super().__init__(MODEM_MANAGER_SERVICE_NAME, object_path, bus)
 		self.messaging = MMModemMessaging(object_path=object_path, bus=bus)
 		self.simple = MMModemSimple(object_path=object_path, bus=bus)
@@ -143,9 +143,9 @@ class MMSim(MMSimInterface):
 		bus: Optional[SdBus] = None,
 	) -> None:
 		"""
-        :param bus: You probably want to set default bus to system bus \
-            or pass system bus directly.
-        """
+		:param bus: You probably want to set default bus to system bus \
+			or pass system bus directly.
+		"""
 		super().__init__(MODEM_MANAGER_SERVICE_NAME, object_path, bus)
 
 
@@ -157,9 +157,9 @@ class MMBearer(MMBearerInterface):
 		bus: Optional[SdBus] = None,
 	) -> None:
 		"""
-        :param bus: You probably want to set default bus to system bus \
-            or pass system bus directly.
-        """
+		:param bus: You probably want to set default bus to system bus \
+			or pass system bus directly.
+		"""
 		super().__init__(MODEM_MANAGER_SERVICE_NAME, object_path, bus)
 
 
@@ -173,29 +173,20 @@ class MMCall(MMCallInterface):
 		"""
 		:param bus: You probably want to set default bus to system bus \
 			or pass system bus directly.
-        """
+		"""
 		super().__init__(MODEM_MANAGER_SERVICE_NAME, object_path, bus)
 
 	@property
 	def state_text(self) -> str:
-		"""A MMCallState name, describing the state of the call.
-		Returns:
-			str: _description_
-		"""
+		"""A MMCallState name, describing the state of the call."""
 		return MMCallState(self.state).name
 
 	@property
 	def state_reason_text(self) -> str:
-		"""A MMCallStateReason name, describing why the state is changed.
-		Returns:
-			str: _description_
-		"""
+		"""A MMCallStateReason name, describing why the state is changed."""
 		return MMCallStateReason(self.state_reason).name
 
 	@property
 	def direction_text(self) -> str:
-		"""A MMCallDirection name, describing the direction of the call.
-		Returns:
-			str: _description_
-		"""
+		"""A MMCallDirection name, describing the direction of the call."""
 		return MMCallDirection(self.direction).name


### PR DESCRIPTION
As a next step I'd like to develop `sdbus_async` functions for SMS reception. The `sdbus_async` is always a modified copy of the `sdbus_block` functions, so before making a copy I thought it would be nice to "polish" the documentation a bit.

I added the `docs` directory with a Sphinx configuration and fixed the Python documentation strings to follow the style described in https://github.com/python-sdbus/python-sdbus/blob/master/docs/autodoc.rst.
The documentation can be generated by `cd docs; sphinx-build -M html . outputdir`. It however contains the auto-generated documentation only-- I did it only as a syntax check to make sure the Python documentation strings (`"""`) are correct.
