### PR TITLE
Added sdbus_async interfaces and objects, plus a SMS reception example

### DIFF
--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -16,7 +16,7 @@ Interfaces
 .. autoclass:: sdbus_block.modemmanager.MMModemSimpleInterface
     :members:
 
-.. autoclass:: sdbus_block.modemmanager.MMModemSingalInterface
+.. autoclass:: sdbus_block.modemmanager.MMModemSignalInterface
     :members:
 
 .. autoclass:: sdbus_block.modemmanager.MMModemVoiceInterface

--- a/example/sms_receive.py
+++ b/example/sms_receive.py
@@ -1,0 +1,16 @@
+import asyncio
+import sdbus
+from sdbus_async.modemmanager import MMModems, MMSms
+
+async def main():
+	sdbus.set_default_bus(sdbus.sd_bus_open_system())
+	modem = await MMModems().get_first()
+	if modem:
+		async for path, received in modem.messaging.added:
+			if received:
+				sms = MMSms(path)
+				print(f'From {await sms.number}: {await sms.text}')
+	else:
+		print('no modem found')
+
+asyncio.run(main())

--- a/sdbus_async/modemmanager/__init__.py
+++ b/sdbus_async/modemmanager/__init__.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from .enums import MMModemState, MMModemMode, MMModemPowerState, MMCallDirection, MMCallState, MMCallStateReason
+from .interfaces_bearer import MMBearerInterfaceAsync
+from .interfaces_call import MMCallInterfaceAsync
+from .interfaces_modem import MMModemInterfaceAsync, MMModemMessagingInterfaceAsync, MMModemSimpleInterfaceAsync, MMModemSignalInterfaceAsync, MMModemsInterfaceAsync, MMModemVoiceInterfaceAsync
+from .interfaces_root import MMInterfaceAsync
+from .interfaces_sim import MMSimInterfaceAsync
+from .interfaces_sms import MMSmsInterfaceAsync
+from .objects import MM, MMBearer, MMCall, MMModem, MMModems, MMModemMessaging, MMModemSignal, MMModemSimple, MMModemVoice, MMSim, MMSms
+
+__all__ = (
+	# .enums
+	'MMModemState',
+	'MMModemMode',
+	'MMModemPowerState',
+	'MMCallDirection',
+	'MMCallState',
+	'MMCallStateReason',
+	# .interfaces_bearer
+	' MMBearerInterfaceAsync',
+	# .interfaces_call
+	'MMCallInterfaceAsync',
+	# .interfaces_modem
+	'MMModemInterfaceAsync',
+	'MMModemMessagingInterfaceAsync',
+	'MMModemSimpleInterfaceAsync',
+	'MMModemSignalInterfaceAsync',
+	'MMModemsInterfaceAsync',
+	'MMModemVoiceInterfaceAsync',
+	# .interfaces_root
+	'MMInterfaceAsync',
+	# .interfaces_sim
+	'MMSimInterfaceAsync',
+	# .interfaces_sms
+	'MMSmsInterfaceAsync',
+	# .objects
+	'MM',
+	'MMModems',
+	'MMModem',
+	'MMModemMessaging',
+	'MMModemSimple',
+	'MMModemSignal',
+	'MMModemVoice',
+	'MMSim',
+	'MMSms',
+	'MMBearer',
+	'MMCall',
+)

--- a/sdbus_async/modemmanager/enums.py
+++ b/sdbus_async/modemmanager/enums.py
@@ -1,0 +1,1 @@
+../../sdbus_block/modemmanager/enums.py

--- a/sdbus_async/modemmanager/interfaces_bearer.py
+++ b/sdbus_async/modemmanager/interfaces_bearer.py
@@ -1,0 +1,125 @@
+from typing import Any, Dict, List, Tuple
+
+from sdbus import DbusInterfaceCommonAsync, dbus_method_async, dbus_property_async
+
+
+class MMBearerInterfaceAsync(DbusInterfaceCommonAsync, interface_name='org.freedesktop.ModemManager1.Bearer'):
+	"""This interface provides access to specific actions that may be performed on available bearers."""
+
+	@dbus_method_async()
+	async def connect(self) -> None:
+		"""
+		Requests activation of a packet data connection with the network using this bearer's properties.
+		Upon successful activation, the modem can send and receive packet data and, depending on the addressing
+		capability of the modem, a connection manager may need to start PPP, perform DHCP, or assign the IP address
+		returned by the modem to the data interface. Upon successful return, the "Ip4Config" and/or "Ip6Config"
+		properties become valid and may contain IP configuration information for the data interface associated with
+		this bearer.
+		"""
+		raise NotImplementedError
+
+	@dbus_method_async()
+	async def disconnect(self) -> None:
+		"""
+		Disconnect and deactivate this packet data connection.
+
+		Any ongoing data session will be terminated and IP addresses become invalid when this method is called.
+		"""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='s')
+	def interface(self) -> str:
+		"""
+		The operating system name for the network data interface that provides packet data using this bearer.
+
+		Connection managers must configure this interface depending on the IP "method" given by the "Ip4Config" or
+		"Ip6Config" properties set by bearer activation.
+
+		If MM_BEARER_IP_METHOD_STATIC or MM_BEARER_IP_METHOD_DHCP methods are given, the interface will be an
+		ethernet-style interface suitable for DHCP or setting static IP configuration on, while if the
+		MM_BEARER_IP_METHOD_PPP method is given, the interface will be a serial TTY which must then have PPP run
+		over it.
+		"""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='b')
+	def connected(self) -> bool:
+		"""
+		Indicates whether or not the bearer is connected and thus whether packet data communication using this bearer
+		is possible.
+		"""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='(ss)')
+	def connection_error(self) -> Tuple[str, str]:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='b')
+	def suspended(self) -> bool:
+		"""
+		In some devices, packet data service will be suspended while the device is handling other communication, like
+		a voice call. If packet data service is suspended (but not deactivated) this property will be TRUE.
+		"""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='b')
+	def multiplexed(self) -> bool:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='a{sv}')
+	def ip4_config(self) -> Dict[str, Tuple[str, Any]]:
+		"""
+		If the bearer was configured for IPv4 addressing, upon activation this property contains the addressing details for assignment to the data interface.
+
+		Mandatory items include:
+
+		"method"
+			A MMBearerIpMethod, given as an unsigned integer value (signature "u").
+			If the bearer specifies configuration via PPP or DHCP, only the "method" item will be present.
+			Additional items which are only applicable when using the MM_BEARER_IP_METHOD_STATIC method are:
+		"address"
+			IP address, given as a string value (signature "s").
+		"prefix"
+			Numeric CIDR network prefix (ie, 24, 32, etc), given as an unsigned integer value (signature "u").
+		"dns1"
+			IP address of the first DNS server, given as a string value (signature "s").
+		"dns2"
+			IP address of the second DNS server, given as a string value (signature "s").
+		"dns3"
+			IP address of the third DNS server, given as a string value (signature "s").
+		"gateway"
+			IP address of the default gateway, given as a string value (signature "s").
+			This property may also include the following items when such information is available:
+		"mtu"
+			Maximum transmission unit (MTU), given as an unsigned integer value (signature "u").
+		"""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='a{sv}')
+	def ip6_config(self) -> Dict[str, Tuple[str, Any]]:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='a{sv}')
+	def stats(self) -> Dict[str, Tuple[str, Any]]:
+		"""If the modem supports it, this property will show statistics associated to the bearer."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='b')
+	def reload_stats_supported(self) -> bool:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='u')
+	def ip_timeout(self) -> int:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='u')
+	def bearer_type(self) -> int:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='i')
+	def profile_id(self) -> int:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='a{sv}')
+	def properties(self) -> Dict[str, Tuple[str, Any]]:
+		raise NotImplementedError

--- a/sdbus_async/modemmanager/interfaces_call.py
+++ b/sdbus_async/modemmanager/interfaces_call.py
@@ -1,0 +1,95 @@
+from typing import Any, Dict, Tuple
+
+from sdbus import DbusInterfaceCommonAsync, dbus_method_async, dbus_property_async, dbus_signal_async
+
+
+class MMCallInterfaceAsync(DbusInterfaceCommonAsync, interface_name='org.freedesktop.ModemManager1.Call'):
+
+	@dbus_method_async()
+	async def start(self) -> None:
+		"""If the outgoing call has not yet been started, start it."""
+		raise NotImplementedError
+
+	@dbus_method_async()
+	async def accept(self) -> None:
+		"""Accept incoming call (answer)."""
+		raise NotImplementedError
+
+	@dbus_method_async(input_signature='s')
+	async def deflect(self, number: str) -> None:
+		"""Deflect an incoming or waiting call to a new number.
+
+		:param number: new number where the call will be deflected.
+		"""
+		raise NotImplementedError
+
+	@dbus_method_async()
+	async def join_multiparty(self) -> None:
+		"""
+		Join the currently held call into a single multiparty call with another already active call.
+		"""
+		raise NotImplementedError
+
+	@dbus_method_async()
+	async def leave_multiparty(self) -> None:
+		"""
+		If this call is part of an ongoing multiparty call, detach it from the multiparty call,
+		put the multiparty call on hold, and activate this one alone.
+		"""
+		raise NotImplementedError
+
+	@dbus_method_async()
+	async def hangup(self) -> None:
+		"""Hangup the active call."""
+		raise NotImplementedError
+
+	@dbus_method_async(input_signature='s')
+	async def send_dtmf(self, dtmf: str) -> None:
+		"""
+		Send a DTMF tone (Dual Tone Multi-Frequency) (only on supported modem).
+
+		:param dtmf: DTMF tone identifier [0-9A-D*#].
+		"""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='i')
+	def state(self) -> int:
+		"""A MMCallState value, describing the state of the call."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='i')
+	def state_reason(self) -> int:
+		"""A MMCallStateReason value, describing why the state is changed."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='i')
+	def direction(self) -> int:
+		"""A MMCallDirection value, describing the direction of the call."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='s')
+	def number(self) -> str:
+		"""The remote phone number."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='b')
+	def multiparty(self) -> bool:
+		"""Whether the call is currently part of a multiparty conference call."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='s')
+	def audio_port(self) -> str:
+		"""Name of the kernel device that provides the audio (if call audio is routed via the host)."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='a{sv}')
+	def audio_format(self) -> Dict[str, Tuple[str, Any]]:
+		raise NotImplementedError
+
+	@dbus_signal_async(signal_signature='s')
+	def dtmf_received(self) -> str:
+		raise NotImplementedError
+
+	@dbus_signal_async(signal_signature='iiu')
+	def state_changed(self) -> Tuple[int, int, int]:
+		raise NotImplementedError

--- a/sdbus_async/modemmanager/interfaces_modem.py
+++ b/sdbus_async/modemmanager/interfaces_modem.py
@@ -1,0 +1,552 @@
+from typing import Any, Dict, List, Tuple
+
+from sdbus import DbusInterfaceCommonAsync, DbusObjectManagerInterfaceAsync, dbus_method_async, dbus_property_async, dbus_signal_async
+
+
+class MMModemsInterfaceAsync(DbusObjectManagerInterfaceAsync):
+	"""
+	Modem objects are exported in DBus with the following path base: /org/freedesktop/ModemManager1/Modems/#, where # 
+	indicates a unique unsigned integer which identifies the object.
+	
+	The Modem objects will export a generic Modem interface which includes common features and actions applicable to 
+	most modem types. This interface, among other actions, allows the management (creation, listing, deletion) of B
+	earer objects which can then be used to request the modem to get in connected state.
+	
+	Modem objects will also export the generic Simple interface. This interface provides an easy access to the most 
+	simple and common operations that may be performed with the modem, including connection and disconnection. Users 
+	of the Simple interface do not need to take care of getting the modem registered, and they also don't need to manage 
+	the creation of bearers themselves. All the logic required to get the modem connected or disconnected is handled 
+	by the Simple interface.
+
+	Modems with specific 3GPP and/or CDMA capabilities will export modem type specific interfaces, like the 3GPP 
+	interface or the CDMA interface.
+	"""
+	pass
+
+
+class MMModemInterfaceAsync(DbusInterfaceCommonAsync, interface_name='org.freedesktop.ModemManager1.Modem'):
+	"""Main modem manager interface"""
+
+	@dbus_method_async(input_signature='b')
+	async def enable(self, enable: bool) -> None:
+		"""
+		Enable or disable the modem.
+
+		When enabled, the modem's radio is powered on and data sessions, voice calls, location services, and Short Message Service may be available.
+		When disabled, the modem enters low-power state and no network-related operations are available.
+
+		:param enable: True to enable the modem and False to disable it.
+		"""
+		raise NotImplementedError
+
+	@dbus_method_async(result_signature='ao')
+	async def list_bearers(self) -> List[str]:
+		raise NotImplementedError
+
+	@dbus_method_async(input_signature='a{sv}', result_signature='o')
+	async def create_bearer(self, properties: Dict[str, Tuple[str, Any]]) -> str:
+		raise NotImplementedError
+
+	@dbus_method_async(input_signature='o')
+	async def delete_bearer(self, bearer: str) -> None:
+		raise NotImplementedError
+
+	@dbus_method_async()
+	async def reset(self) -> None:
+		raise NotImplementedError
+
+	@dbus_method_async(input_signature='s')
+	async def factory_reset(self, code: str) -> None:
+		raise NotImplementedError
+
+	@dbus_method_async(input_signature='u')
+	async def set_power_state(self, state: int) -> None:
+		raise NotImplementedError
+
+	@dbus_method_async(input_signature='u')
+	async def set_current_capabilities(self, capabilities: int) -> None:
+		raise NotImplementedError
+
+	@dbus_method_async(input_signature='(uu)')
+	async def set_current_modes(self, modes: Tuple[int, int]) -> None:
+		raise NotImplementedError
+
+	@dbus_method_async(input_signature='au')
+	async def set_current_bands(self, bands: List[int]) -> None:
+		raise NotImplementedError
+
+	@dbus_method_async(input_signature='u')
+	async def set_primary_sim_slot(self, sim_slot: int) -> None:
+		raise NotImplementedError
+
+	@dbus_method_async(result_signature='aa{sv}')
+	async def get_cell_info(self) -> List[Dict[str, Tuple[str, Any]]]:
+		raise NotImplementedError
+
+	@dbus_method_async(input_signature='su', result_signature='s')
+	async def command(self, cmd: str, timeout: int) -> str:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='o', property_name='Sim')
+	def sim_object_path(self) -> str:
+		"""The path of the SIM object available in this device, if any."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='ao')
+	def sim_slots(self) -> List[str]:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='u')
+	def primary_sim_slot(self) -> int:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='ao', property_name='Bearers')
+	def bearer_object_paths(self) -> List[str]:
+		"""
+		The list of bearer object paths (EPS Bearers, PDP Contexts, or CDMA2000 Packet Data Sessions) as requested by 
+		the user.
+		This list does not include the initial EPS bearer details (see "InitialEpsBearer").
+		"""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='au')
+	def supported_capabilities(self) -> List[int]:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='u')
+	def current_capabilities(self) -> int:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='u')
+	def max_bearers(self) -> int:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='u')
+	def max_active_bearers(self) -> int:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='u')
+	def max_active_multiplexed_bearers(self) -> int:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='s')
+	def manufacturer(self) -> str:
+		"""The equipment manufacturer, as reported by the modem."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='s')
+	def model(self) -> str:
+		"""The equipment model, as reported by the modem."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='s')
+	def revision(self) -> str:
+		"""The revision identification of the software, as reported by the modem."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='s')
+	def carrier_configuration(self) -> str:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='s')
+	def carrier_configuration_revision(self) -> str:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='s')
+	def hardware_revision(self) -> str:
+		"""The revision identification of the hardware, as reported by the modem."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='s')
+	def device_identifier(self) -> str:
+		"""
+		A best-effort device identifier based on various device information like model name, firmware revision, 
+		USB/PCI/PCMCIA IDs, and other properties.
+		This ID is not guaranteed to be unique and may be shared between identical devices with the same firmware, but 
+		is intended to be "unique enough" for use as a casual device identifier for various user experience operations.
+		This is not the device's IMEI or ESN since those may not be available before unlocking the device via a PIN.
+		"""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='s')
+	def device(self) -> str:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='as')
+	def drivers(self) -> List[str]:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='s')
+	def plugin(self) -> str:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='s')
+	def primary_port(self) -> str:
+		"""The name of the primary port using to control the modem."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='a(su)')
+	def ports(self) -> List[Tuple[str, int]]:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='s')
+	def equipment_identifier(self) -> str:
+		"""
+		The identity of the device.
+		This will be the IMEI number for GSM devices and the hex-format ESN/MEID for CDMA devices.
+		"""
+		raise NotImplementedError
+
+	@property
+	def imei(self):
+		return self.equipment_identifier
+
+	@dbus_property_async(property_signature='u')
+	def unlock_required(self) -> int:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='a{uu}')
+	def unlock_retries(self) -> Dict[int, int]:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='i')
+	def state(self) -> int:
+		"""
+		Overall state of the modem, given as a MMModemState value.
+		If the device's state cannot be determined, MM_MODEM_STATE_UNKNOWN will be reported.
+		"""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='u')
+	def state_failed_reason(self) -> int:
+		"""
+		Error specifying why the modem is in MM_MODEM_STATE_FAILED state,
+		given as a MMModemStateFailedReason value.
+		"""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='u')
+	def access_technologies(self) -> int:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='(ub)')
+	def signal_quality(self) -> Tuple[int, bool]:
+		"""
+		Signal quality in percent (0 - 100) of the dominant access technology the device is using to communicate with the network. Always 0 for POTS devices.
+		The additional boolean value indicates if the quality value given was recently taken.		
+		"""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='as')
+	def own_numbers(self) -> List[str]:
+		"""List of numbers (e.g. MSISDN in 3GPP) being currently handled by this modem."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='u')
+	def power_state(self) -> int:
+		"""A MMModemPowerState value specifying the current power state of the modem."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='a(uu)')
+	def supported_modes(self) -> List[Tuple[int, int]]:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='(uu)')
+	def current_modes(self) -> Tuple[int, int]:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='au')
+	def supported_bands(self) -> List[int]:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='au')
+	def current_bands(self) -> List[int]:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='u')
+	def supported_ip_families(self) -> int:
+		raise NotImplementedError
+
+	@dbus_signal_async(signal_signature='iiu')
+	def state_changed(self) -> Tuple[int, int, int]:
+		raise NotImplementedError
+
+
+class MMModemMessagingInterfaceAsync(DbusInterfaceCommonAsync, interface_name='org.freedesktop.ModemManager1.Modem.Messaging'):
+	"""The Messaging interface handles sending SMS messages and notification of new incoming messages."""
+
+	@dbus_method_async(result_signature='ao')
+	async def list(self) -> List[str]:
+		"""Retrieve all SMS messages."""
+		raise NotImplementedError
+
+	@dbus_method_async(input_signature='o')
+	async def delete(self, path: str) -> None:
+		"""Delete an SMS message."""
+		raise NotImplementedError
+
+	@dbus_method_async(input_signature='a{sv}', result_signature='o')
+	async def create(self, properties: Dict[str, Tuple[str, Any]]) -> str:
+		"""Creates a new message object."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='ao')
+	def messages(self) -> List[str]:
+		"""The list of SMS object paths."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='au')
+	def supported_storages(self) -> List[int]:
+		"""A list of MMSmsStorage values, specifying the storages supported by this modem for storing and receiving SMS."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='u')
+	def default_storage(self) -> int:
+		"""A MMSmsStorage value, specifying the storage to be used when receiving or storing SMS."""
+		raise NotImplementedError
+
+	@dbus_signal_async(signal_signature='ob')
+	def added(self) -> Tuple[str, bool]:
+		"""Emitted when any part of a new SMS has been received or added (but not for subsequent parts, if any)."""
+		raise NotImplementedError
+
+	@dbus_signal_async(signal_signature='o')
+	def deleted(self) -> str:
+		"""Emitted when a message has been deleted."""
+		raise NotImplementedError
+
+
+class MMModemSimpleInterfaceAsync(DbusInterfaceCommonAsync, interface_name='org.freedesktop.ModemManager1.Modem.Simple'):
+
+	@dbus_method_async(input_signature='a{sv}', result_signature='o')
+	async def connect(self, properties: Dict[str, Tuple[str, Any]]) -> str:
+		"""
+		Allowed key/value pairs in properties are:
+
+		"pin"
+			SIM-PIN unlock code, given as a string value (signature "s").
+		"operator-id"
+			ETSI MCC-MNC of a network to force registration with, given as a string value (signature "s").
+		"apn"
+			For GSM/UMTS and LTE devices the APN to use, given as a string value (signature "s").
+		"ip-type"
+			For GSM/UMTS and LTE devices the IP addressing type to use, given as a MMBearerIpFamily value (signature "u").
+		"allowed-auth"
+			The authentication method to use, given as a MMBearerAllowedAuth value (signature "u"). Optional in 3GPP.
+		"user"
+			User name (if any) required by the network, given as a string value (signature "s"). Optional in 3GPP.
+		"password"
+			Password (if any) required by the network, given as a string value (signature "s"). Optional in 3GPP.
+		"number"
+			For POTS devices the number to dial, given as a string value (signature "s").
+		"allow-roaming"
+			False to allow only connections to home networks, given as a boolean value (signature "b").
+		"rm-protocol"
+			For CDMA devices, the protocol of the Rm interface, given as a MMModemCdmaRmProtocol value (signature "u").
+
+		:param properties: Dictionary of properties needed to get the modem connected.
+		:returns: On successful connect, returns the object path of the connected packet data bearer used for the connection attempt.
+		"""
+		raise NotImplementedError
+
+	@dbus_method_async(input_signature='o')
+	async def disconnect(self, bearer: str) -> None:
+		"""
+		data bearer, while if "/" (ie, no object given) this method will disconnect all active packet data bearers.
+		Disconnect an active packet data connection.
+		:param bearer: If given this method will disconnect the referenced packet
+		"""
+		raise NotImplementedError
+
+	@dbus_method_async(result_signature='a{sv}')
+	async def get_status(self) -> Dict[str, Tuple[str, Any]]:
+		"""
+		Get the general modem status.
+
+		The predefined common properties returned are:
+
+		"state"
+			A MMModemState value specifying the overall state of the modem, given as an unsigned integer value (signature "u").
+		"signal-quality"
+			Signal quality value, given only when registered, as an unsigned integer value (signature "u").
+		"current-bands"
+			List of MMModemBand values, given only when registered, as a list of unsigned integer values (signature "au").
+		"access-technology"
+			A MMModemAccessTechnology value, given only when registered, as an unsigned integer value (signature "u").
+		"m3gpp-registration-state"
+			A MMModem3gppRegistrationState value specifying the state of the registration, given only when registered in a 3GPP network, as an unsigned integer value (signature "u").
+		"m3gpp-operator-code"
+			Operator MCC-MNC, given only when registered in a 3GPP network, as a string value (signature "s").
+		"m3gpp-operator-name"
+			Operator name, given only when registered in a 3GPP network, as a string value (signature "s").
+		"cdma-cdma1x-registration-state"
+			A MMModemCdmaRegistrationState value specifying the state of the registration, given only when registered in a CDMA1x network, as an unsigned integer value (signature "u").
+		"cdma-evdo-registration-state"
+			A MMModemCdmaRegistrationState value specifying the state of the registration, given only when registered in a EV-DO network, as an unsigned integer value (signature "u").
+		"cdma-sid"
+			The System Identifier of the serving network, if registered in a CDMA1x network and if known. Given as an unsigned integer value (signature "u").
+		"cdma-nid"
+			The Network Identifier of the serving network, if registered in a CDMA1x network and if known. Given as an unsigned integer value (signature "u").
+		
+		:returns: Dictionary of properties.
+		"""
+		raise NotImplementedError
+
+
+class MMModemSignalInterfaceAsync(DbusInterfaceCommonAsync, interface_name='org.freedesktop.ModemManager1.Modem.Signal'):
+
+	@dbus_method_async(input_signature='u')
+	async def setup(self, rate: int) -> None:
+		"""Setup extended signal quality information retrieval.
+		
+		:param rate: Refresh rate to set, in seconds. 0 to disable retrieval.
+		"""
+		raise NotImplementedError
+
+	@dbus_method_async(input_signature='a{sv}')
+	async def setup_thresholds(self, settings: Dict[str, Tuple[str, Any]]) -> None:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='u')
+	def rate(self) -> int:
+		"""
+		Refresh rate for the extended signal quality information updates, in seconds.
+		A value of 0 disables the retrieval of the values.
+		"""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='u')
+	def rssi_threshold(self) -> int:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='b')
+	def error_rate_threshold(self) -> bool:
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='a{sv}')
+	def cdma(self) -> Dict[str, Tuple[str, Any]]:
+		"""
+		Dictionary of available signal information for the CDMA1x access technology.
+		"""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='a{sv}')
+	def evdo(self) -> Dict[str, Tuple[str, Any]]:
+		"""
+		Dictionary of available signal information for the CDMA EV-DO access technology.
+		"""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='a{sv}')
+	def gsm(self) -> Dict[str, Tuple[str, Any]]:
+		"""
+		Dictionary of available signal information for the GSM/GPRS access technology.
+		"""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='a{sv}')
+	def umts(self) -> Dict[str, Tuple[str, Any]]:
+		"""
+		Dictionary of available signal information for the UMTS (WCDMA) access technology.
+		"""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='a{sv}')
+	def lte(self) -> Dict[str, Tuple[str, Any]]:
+		"""
+		Dictionary of available signal information for the LTE access technology.
+		"""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='a{sv}')
+	def nr5g(self) -> Dict[str, Tuple[str, Any]]:
+		"""
+		Dictionary of available signal information for the 5G access technology.
+		"""
+		raise NotImplementedError
+
+
+class MMModemVoiceInterfaceAsync(DbusInterfaceCommonAsync, interface_name='org.freedesktop.ModemManager1.Modem.Voice'):
+
+	@dbus_method_async(result_signature='ao')
+	async def list_calls(self) -> List[str]:
+		"""
+		Retrieve all Calls.
+
+		:returns: The list of call object paths.
+		"""
+		raise NotImplementedError
+
+	@dbus_method_async(input_signature='o')
+	async def delete_call(self, path: str) -> None:
+		"""
+		Delete a Call from the list of calls.
+		The call will be hangup if it is still active.
+
+		:param path: The object path of the Call to delete.
+		"""
+		raise NotImplementedError
+
+	@dbus_method_async(input_signature='a{sv}', result_signature='o')
+	async def create_call(self, properties: Dict[str, Tuple[str, Any]]) -> str:
+		"""
+		Creates a new call object for a new outgoing call.
+		The 'Number' is the only expected property to set by the user.
+
+		:param properties: Call properties from the Call D-Bus interface.
+		:returns: The object path of the new call object.
+		"""
+		raise NotImplementedError
+
+	@dbus_method_async()
+	async def hold_and_accept(self) -> None:
+		"""Place all active calls on hold, if any, and accept the next call."""
+		raise NotImplementedError
+
+	@dbus_method_async()
+	async def hangup_and_accept(self) -> None:
+		"""Hangup all active calls, if any, and accept the next call."""
+		raise NotImplementedError
+
+	@dbus_method_async()
+	async def hangup_all(self) -> None:
+		"""Hangup all active calls."""
+		raise NotImplementedError
+
+	@dbus_method_async()
+	async def transfer(self) -> None:
+		"""
+		Join the currently active and held calls together into a single multiparty call,
+		but disconnects from them.
+		"""
+		raise NotImplementedError
+
+	@dbus_method_async(input_signature='b')
+	async def call_waiting_setup(self, enable: bool) -> None:
+		"""Activates or deactivates the call waiting network service, as per 3GPP TS 22.083."""
+		raise NotImplementedError
+
+	@dbus_method_async(result_signature='b')
+	async def call_waiting_query(self) -> bool:
+		"""Queries the status of the call waiting network service, as per 3GPP TS 22.083."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='ao', property_name='Calls')
+	def call_object_paths(self) -> List[str]:
+		"""The list of calls object paths."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='b')
+	def emergency_only(self) -> bool:
+		"""A flag indicating whether emergency calls are the only allowed ones."""
+		raise NotImplementedError
+
+	@dbus_signal_async(signal_signature='o')
+	def call_added(self) -> str:
+		"""Emitted when a call has been added."""
+		raise NotImplementedError
+
+	@dbus_signal_async(signal_signature='o')
+	def call_deleted(self) -> str:
+		"""Emitted when a call has been deleted."""
+		raise NotImplementedError

--- a/sdbus_async/modemmanager/interfaces_root.py
+++ b/sdbus_async/modemmanager/interfaces_root.py
@@ -1,0 +1,39 @@
+from typing import Any, Dict, List, Tuple
+
+from sdbus import DbusInterfaceCommonAsync, dbus_method_async, dbus_property_async
+
+
+class MMInterfaceAsync(DbusInterfaceCommonAsync, interface_name='org.freedesktop.ModemManager1'):
+	"""Main modem manager interface"""
+
+	@dbus_method_async()
+	async def scan_devices(self) -> None:
+		"""Start a new scan for connected modem devices."""
+		raise NotImplementedError
+
+	@dbus_method_async(input_signature='s')
+	async def set_logging(self, level: str) -> None:
+		"""Set logging verbosity.
+
+		:param level: One of "ERR", "WARN", "INFO", "DEBUG".
+		"""
+		raise NotImplementedError
+
+	@dbus_method_async(input_signature='a{sv}')
+	async def report_kernel_event(self, properties: Dict[str, Tuple[str, Any]]) -> None:
+		"""Reports a kernel event to ModemManager."""
+		raise NotImplementedError
+
+	@dbus_method_async(input_signature='sb')
+	async def inhibit_device(self, uid: str, inhibit: bool) -> None:
+		"""Inhibit or uninhibit the device.
+
+		:param uid: The unique ID of the physical device
+		:param inhibit: True to inhibit the modem and False to uninhibit it
+		"""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='s')
+	def version(self) -> str:
+		"""NetworkManager version"""
+		raise NotImplementedError

--- a/sdbus_async/modemmanager/interfaces_sim.py
+++ b/sdbus_async/modemmanager/interfaces_sim.py
@@ -1,13 +1,13 @@
 from typing import List, Tuple
 
-from sdbus import DbusInterfaceCommon, dbus_method, dbus_property
+from sdbus import DbusInterfaceCommonAsync, dbus_method_async, dbus_property_async
 
 
-class MMSimInterface(DbusInterfaceCommon, interface_name='org.freedesktop.ModemManager1.Sim'):
+class MMSimInterfaceAsync(DbusInterfaceCommonAsync, interface_name='org.freedesktop.ModemManager1.Sim'):
 	"""The SIM interface handles communication with SIM, USIM, and RUIM (CDMA SIM) cards."""
 
-	@dbus_method(input_signature='s')
-	def send_pin(self, pin: str = '') -> None:
+	@dbus_method_async(input_signature='s')
+	async def send_pin(self, pin: str) -> None:
 		"""
 		Send the PIN to unlock the SIM card.
 
@@ -15,8 +15,8 @@ class MMSimInterface(DbusInterfaceCommon, interface_name='org.freedesktop.ModemM
 		"""
 		raise NotImplementedError
 
-	@dbus_method(input_signature='ss')
-	def send_puk(self, puk: str = '', pin: str = '') -> None:
+	@dbus_method_async(input_signature='ss')
+	async def send_puk(self, puk: str, pin: str) -> None:
 		"""
 		Send the PUK and a new PIN to unlock the SIM card.
 
@@ -25,8 +25,8 @@ class MMSimInterface(DbusInterfaceCommon, interface_name='org.freedesktop.ModemM
 		"""
 		raise NotImplementedError
 
-	@dbus_method(input_signature='sb')
-	def enable_pin(self, pin: str = '', enable: bool = False) -> None:
+	@dbus_method_async(input_signature='sb')
+	async def enable_pin(self, pin: str, enable: bool) -> None:
 		"""
 		Enable or disable the PIN checking.
 
@@ -35,8 +35,8 @@ class MMSimInterface(DbusInterfaceCommon, interface_name='org.freedesktop.ModemM
 		"""
 		raise NotImplementedError
 
-	@dbus_method(input_signature='ss')
-	def change_pin(self, old_pin: str = '', new_pin: str = '') -> None:
+	@dbus_method_async(input_signature='ss')
+	async def change_pin(self, old_pin: str, new_pin: str) -> None:
 		"""
 		Change the PIN code.
 
@@ -45,8 +45,8 @@ class MMSimInterface(DbusInterfaceCommon, interface_name='org.freedesktop.ModemM
 		"""
 		raise NotImplementedError
 
-	@dbus_method(input_signature='a(su)')
-	def set_preferred_networks(self, preferred_networks: List[Tuple[str, int]]) -> None:
+	@dbus_method_async(input_signature='a(su)')
+	async def set_preferred_networks(self, preferred_networks: List[Tuple[str, int]]) -> None:
 		"""
 		Stores the provided preferred network list to the SIM card.
 
@@ -57,12 +57,12 @@ class MMSimInterface(DbusInterfaceCommon, interface_name='org.freedesktop.ModemM
 		"""
 		raise NotImplementedError
 
-	@dbus_property(property_signature='b')
+	@dbus_property_async(property_signature='b')
 	def active(self) -> bool:
 		"""Boolean indicating whether the SIM is currently active."""
 		raise NotImplementedError
 
-	@dbus_property('s')
+	@dbus_property_async(property_signature='s')
 	def sim_identifier(self) -> str:
 		"""
 		The ICCID of the SIM card.
@@ -70,31 +70,31 @@ class MMSimInterface(DbusInterfaceCommon, interface_name='org.freedesktop.ModemM
 		"""
 		raise NotImplementedError
 
-	@dbus_property('s')
+	@dbus_property_async(property_signature='s')
 	def imsi(self) -> str:
 		"""The IMSI of the SIM card, if any."""
 		raise NotImplementedError
 
-	@dbus_property(property_signature='s')
+	@dbus_property_async(property_signature='s')
 	def eid(self) -> str:
 		"""The EID of the SIM card, if any."""
 		raise NotImplementedError
 
-	@dbus_property('s')
+	@dbus_property_async(property_signature='s')
 	def operator_identifier(self) -> str:
 		raise NotImplementedError
 
-	@dbus_property('s')
+	@dbus_property_async(property_signature='s')
 	def operator_name(self) -> str:
 		"""The name of the network operator, as given by the SIM card, if known."""
 		raise NotImplementedError
 
-	@dbus_property(property_signature='as')
+	@dbus_property_async(property_signature='as')
 	def emergency_numbers(self) -> List[str]:
 		"""List of emergency numbers programmed in the SIM card."""
 		raise NotImplementedError
 
-	@dbus_property(property_signature='a(su)')
+	@dbus_property_async(property_signature='a(su)')
 	def preferred_networks(self) -> List[Tuple[str, int]]:
 		"""
 		List of preferred networks with access technologies configured in the SIM card.
@@ -104,27 +104,27 @@ class MMSimInterface(DbusInterfaceCommon, interface_name='org.freedesktop.ModemM
 		"""
 		raise NotImplementedError
 
-	@dbus_property(property_signature='ay')
+	@dbus_property_async(property_signature='ay')
 	def gid1(self) -> bytes:
 		"""Group identifier level 1."""
 		raise NotImplementedError
 
-	@dbus_property(property_signature='ay')
+	@dbus_property_async(property_signature='ay')
 	def gid2(self) -> bytes:
 		"""Group identifier level 2."""
 		raise NotImplementedError
 
-	@dbus_property(property_signature='u')
+	@dbus_property_async(property_signature='u')
 	def sim_type(self) -> int:
 		"""Indicates whether the current primary SIM is a ESIM or a physical SIM, given as MMSimType value."""
 		raise NotImplementedError
 
-	@dbus_property(property_signature='u')
+	@dbus_property_async(property_signature='u')
 	def esim_status(self) -> int:
 		"""If current SIM is ESIM then this indicates whether there is a profile or not, given as MMSimEsimStatus value."""
 		raise NotImplementedError
 
-	@dbus_property(property_signature='u')
+	@dbus_property_async(property_signature='u')
 	def removability(self) -> int:
 		"""Indicates whether the current SIM is a removable SIM or not, given as a MMSimRemovability value."""
 		raise NotImplementedError

--- a/sdbus_async/modemmanager/interfaces_sms.py
+++ b/sdbus_async/modemmanager/interfaces_sms.py
@@ -1,0 +1,97 @@
+from typing import Any, Tuple
+
+from sdbus import DbusInterfaceCommonAsync, dbus_method_async, dbus_property_async
+
+
+class MMSmsInterfaceAsync(DbusInterfaceCommonAsync, interface_name='org.freedesktop.ModemManager1.Sms'):
+	"""The SMS interface defines operations and properties of a single SMS message."""
+
+	@dbus_method_async()
+	async def send(self) -> None:
+		"""If the message has not yet been sent, queue it for delivery."""
+		raise NotImplementedError
+
+	@dbus_method_async(input_signature='u')
+	async def store(self, storage: int) -> None:
+		"""Store the message in the device if not already done."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='u')
+	def state(self) -> int:
+		"""A MMSmsState value, describing the state of the message."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='u')
+	def pdu_type(self) -> int:
+		"""A MMSmsPduType value, describing the type of PDUs used in the SMS message."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='s')
+	def number(self) -> str:
+		"""Number to which the message is addressed."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='s')
+	def text(self) -> str:
+		"""Message text, in UTF-8."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='ay')
+	def data(self) -> bytes:
+		"""Message data."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='s')
+	def s_m_s_c(self) -> str:
+		"""Indicates the SMS service center number."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='(uv)')
+	def validity(self) -> Tuple[int, Tuple[str, Any]]:
+		"""Indicates when the SMS expires in the SMSC."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='i')
+	def Class(self) -> int:
+		"""3GPP message class (-1..3)."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='u')
+	def teleservice_id(self) -> int:
+		"""A MMSmsCdmaTeleserviceId value."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='u')
+	def service_category(self) -> int:
+		"""A MMSmsCdmaServiceCategory value."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='b')
+	def delivery_report_request(self) -> bool:
+		"""True if delivery report request is required, False otherwise."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='u')
+	def message_reference(self) -> int:
+		"""Message Reference of the last PDU sent/received within this SMS."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='s')
+	def timestamp(self) -> str:
+		"""Time when the first PDU of the SMS message arrived the SMSC, in ISO8601 format."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='s')
+	def discharge_timestamp(self) -> str:
+		"""Time when the first PDU of the SMS message left the SMSC, in ISO8601 format."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='u')
+	def delivery_state(self) -> int:
+		"""A MMSmsDeliveryState value, describing the state of the delivery reported in the Status Report message."""
+		raise NotImplementedError
+
+	@dbus_property_async(property_signature='u')
+	def storage(self) -> int:
+		"""A MMSmsStorage value, describing the storage where this message is kept."""
+		raise NotImplementedError

--- a/sdbus_async/modemmanager/objects.py
+++ b/sdbus_async/modemmanager/objects.py
@@ -1,0 +1,204 @@
+from typing import Dict, List, Optional
+
+from sdbus.sd_bus_internals import SdBus
+
+from .enums import MMCallDirection, MMCallState, MMCallStateReason
+from .interfaces_bearer import MMBearerInterfaceAsync
+from .interfaces_call import MMCallInterfaceAsync
+from .interfaces_modem import MMModemInterfaceAsync, MMModemMessagingInterfaceAsync, MMModemSimpleInterfaceAsync, MMModemSignalInterfaceAsync, MMModemsInterfaceAsync, MMModemVoiceInterfaceAsync
+from .interfaces_root import MMInterfaceAsync
+from .interfaces_sim import MMSimInterfaceAsync
+from .interfaces_sms import MMSmsInterfaceAsync
+
+MODEM_MANAGER_SERVICE_NAME = 'org.freedesktop.ModemManager1'
+
+
+class MM(MMInterfaceAsync):
+	"""Modem Manger main object
+
+	Implements :py:class:`ModemManagerInterfaceAsync`
+
+	Service name ``'org.freedesktop.ModemManager1'``
+	and object path ``/org/freedesktop/ModemManager1`` is predetermined.
+	"""
+
+	def __init__(self, bus: Optional[SdBus] = None) -> None:
+		"""
+		:param bus: You probably want to set default bus to system bus \
+			or pass system bus directly.
+		"""
+		super().__init__()
+		self._connect(MODEM_MANAGER_SERVICE_NAME, '/org/freedesktop/ModemManager1', bus)
+
+
+class MMSms(MMSmsInterfaceAsync):
+
+	def __init__(
+		self,
+		object_path: str,
+		bus: Optional[SdBus] = None,
+	) -> None:
+		"""
+		:param bus: You probably want to set default bus to system bus \
+			or pass system bus directly.
+		"""
+		super().__init__()
+		self._connect(MODEM_MANAGER_SERVICE_NAME, object_path, bus)
+
+
+class MMModemMessaging(MMModemMessagingInterfaceAsync):
+
+	def __init__(self, object_path: str, bus: Optional[SdBus] = None) -> None:
+		super().__init__()
+		self._connect(MODEM_MANAGER_SERVICE_NAME, object_path, bus)
+
+	async def create_sms(self, number: str, text: str = None, data: bytes = None) -> MMSms:
+		"""Creates a new message object."""
+		args = {"number": ("s", number)}
+		if text:
+			args["text"] = ("s", text)
+		elif data:
+			args["data"] = ("ay", data)
+
+		return MMSms(self.create(properties=args))
+
+	async def delete_sms(self, sms: MMSms) -> None:
+		"""Delete an SMS message."""
+		self.delete(sms._remote_object_path)
+
+
+class MMModemSignal(MMModemSignalInterfaceAsync):
+
+	def __init__(self, object_path: str, bus: Optional[SdBus] = None) -> None:
+		"""
+		:param bus: You probably want to set default bus to system bus \
+			or pass system bus directly.
+		"""
+		super().__init__()
+		self._connect(MODEM_MANAGER_SERVICE_NAME, object_path, bus)
+
+
+class MMModemSimple(MMModemSimpleInterfaceAsync):
+
+	def __init__(self, object_path: str, bus: Optional[SdBus] = None) -> None:
+		super().__init__()
+		self._connect(MODEM_MANAGER_SERVICE_NAME, object_path, bus)
+
+
+class MMModemVoice(MMModemVoiceInterfaceAsync):
+
+	def __init__(self, object_path: str, bus: Optional[SdBus] = None) -> None:
+		super().__init__()
+		self._connect(MODEM_MANAGER_SERVICE_NAME, object_path, bus)
+
+	async def get_calls(self):
+		return [MMCall(path) for path in self.call_object_paths]
+
+
+class MMModem(MMModemInterfaceAsync):
+
+	def __init__(
+		self,
+		object_path: str,
+		bus: Optional[SdBus] = None,
+	) -> None:
+		"""
+		:param bus: You probably want to set default bus to system bus \
+			or pass system bus directly.
+		"""
+		super().__init__()
+		self._connect(MODEM_MANAGER_SERVICE_NAME, object_path, bus)
+		self.messaging = MMModemMessaging(object_path=object_path, bus=bus)
+		self.simple = MMModemSimple(object_path=object_path, bus=bus)
+		self.signal = MMModemSignal(object_path=object_path, bus=bus)
+		self.voice = MMModemVoice(object_path=object_path, bus=bus)
+		self.sim: Optional[MMSim] = None
+		self.bearers: List[MMBearer] = []
+
+	async def set_sim(self, object_path: str):
+		self.sim = MMSim(object_path=object_path)
+
+	async def set_bearers(self, object_paths: List[str]):
+		for p in object_paths:
+			b = MMBearer(p)
+			self.bearers.append(b)
+
+
+class MMModems(MMModemsInterfaceAsync):
+	modems: List[MMModem] = []
+
+	def __init__(self, bus: Optional[SdBus] = None) -> None:
+		super().__init__()
+		self._connect(service_name=MODEM_MANAGER_SERVICE_NAME, object_path='/org/freedesktop/ModemManager1', bus=bus)
+
+	async def get_modems(self) -> List[MMModem]:
+		objects = await self.get_managed_objects()
+		for k, v in objects.items():
+			m: MMModem = MMModem(object_path=k)
+			self.modems.append(m)
+		return self.modems
+
+	async def get_first(self) -> Optional[MMModem]:
+		if len(self.modems) <= 0:
+			await self.get_modems()
+		return self.modems[0] if len(self.modems) >= 1 else None
+
+
+class MMSim(MMSimInterfaceAsync):
+
+	def __init__(
+		self,
+		object_path: str,
+		bus: Optional[SdBus] = None,
+	) -> None:
+		"""
+		:param bus: You probably want to set default bus to system bus \
+			or pass system bus directly.
+		"""
+		super().__init__()
+		self._connect(MODEM_MANAGER_SERVICE_NAME, object_path, bus)
+
+
+class MMBearer(MMBearerInterfaceAsync):
+
+	def __init__(
+		self,
+		object_path: str,
+		bus: Optional[SdBus] = None,
+	) -> None:
+		"""
+		:param bus: You probably want to set default bus to system bus \
+			or pass system bus directly.
+		"""
+		super().__init__()
+		self._connect(MODEM_MANAGER_SERVICE_NAME, object_path, bus)
+
+
+class MMCall(MMCallInterfaceAsync):
+
+	def __init__(
+		self,
+		object_path: str,
+		bus: Optional[SdBus] = None,
+	) -> None:
+		"""
+		:param bus: You probably want to set default bus to system bus \
+			or pass system bus directly.
+		"""
+		super().__init__()
+		self._connect(MODEM_MANAGER_SERVICE_NAME, object_path, bus)
+
+	@property
+	def state_text(self) -> str:
+		"""A MMCallState name, describing the state of the call."""
+		return MMCallState(self.state).name
+
+	@property
+	def state_reason_text(self) -> str:
+		"""A MMCallStateReason name, describing why the state is changed."""
+		return MMCallStateReason(self.state_reason).name
+
+	@property
+	def direction_text(self) -> str:
+		"""A MMCallDirection name, describing the direction of the call."""
+		return MMCallDirection(self.direction).name

--- a/sdbus_block/modemmanager/__init__.py
+++ b/sdbus_block/modemmanager/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from .enums import MMModemState, MMModemMode, MMModemPowerState, MMCallDirection, MMCallState, MMCallStateReason
 from .interfaces_bearer import MMBearerInterface
 from .interfaces_call import MMCallInterface
-from .interfaces_modem import MMModemInterface, MMModemMessagingInterface, MMModemSimpleInterface, MMModemSingalInterface, MMModemsInterface, MMModemVoiceInterface
+from .interfaces_modem import MMModemInterface, MMModemMessagingInterface, MMModemSimpleInterface, MMModemSignalInterface, MMModemsInterface, MMModemVoiceInterface
 from .interfaces_root import MMInterface
 from .interfaces_sim import MMSimInterface
 from .interfaces_sms import MMSmsInterface
@@ -25,7 +25,7 @@ __all__ = (
 	'MMModemInterface',
 	'MMModemMessagingInterface',
 	'MMModemSimpleInterface',
-	'MMModemSingalInterface',
+	'MMModemSignalInterface',
 	'MMModemsInterface',
 	'MMModemVoiceInterface',
 	# .interfaces_root

--- a/sdbus_block/modemmanager/interfaces_modem.py
+++ b/sdbus_block/modemmanager/interfaces_modem.py
@@ -257,7 +257,7 @@ class MMModemSimpleInterface(DbusInterfaceCommon, interface_name='org.freedeskto
 		raise NotImplementedError
 
 
-class MMModemSingalInterface(DbusInterfaceCommon, interface_name='org.freedesktop.ModemManager1.Modem.Signal'):
+class MMModemSignalInterface(DbusInterfaceCommon, interface_name='org.freedesktop.ModemManager1.Modem.Signal'):
 
 	@dbus_method('u')
 	def setup(self, rate: int):

--- a/sdbus_block/modemmanager/interfaces_root.py
+++ b/sdbus_block/modemmanager/interfaces_root.py
@@ -19,6 +19,20 @@ class MMInterface(DbusInterfaceCommon, interface_name='org.freedesktop.ModemMana
 		"""
 		raise NotImplementedError
 
+	@dbus_method(input_signature='a{sv}')
+	def report_kernel_event(self, properties: Dict[str, Tuple[str, Any]]) -> None:
+		"""Reports a kernel event to ModemManager."""
+		raise NotImplementedError
+
+	@dbus_method(input_signature='sb')
+	def inhibit_device(self, uid: str, inhibit: bool) -> None:
+		"""Inhibit or uninhibit the device.
+
+		:param uid: The unique ID of the physical device
+		:param inhibit: True to inhibit the modem and False to uninhibit it
+		"""
+		raise NotImplementedError
+
 	@dbus_property('s')
 	def version(self) -> str:
 		"""NetworkManager version"""

--- a/sdbus_block/modemmanager/interfaces_sim.py
+++ b/sdbus_block/modemmanager/interfaces_sim.py
@@ -1,3 +1,5 @@
+from typing import List, Tuple
+
 from sdbus import DbusInterfaceCommon, dbus_method, dbus_property
 
 
@@ -24,7 +26,7 @@ class MMSimInterface(DbusInterfaceCommon, interface_name='org.freedesktop.ModemM
 		raise NotImplementedError
 
 	@dbus_method(input_signature='sb')
-	def enable_pin(self, pin: str = '', enable: bool = False) -> None:
+	def enable_pin(self, pin: str = '', enabled: bool = False) -> None:
 		"""
 		Enable or disable the PIN checking.
 
@@ -43,6 +45,23 @@ class MMSimInterface(DbusInterfaceCommon, interface_name='org.freedesktop.ModemM
 		"""
 		raise NotImplementedError
 
+	@dbus_method(input_signature='a(su)')
+	def set_preferred_networks(self, preferred_networks: List[Tuple[str, int]]) -> None:
+		"""
+		Stores the provided preferred network list to the SIM card.
+
+		Each entry contains an operator id string ("MCCMNC") consisting of 5 or 6 digits,
+		and an MMModemAccessTechnology mask to store to SIM card if supported.
+
+		:param preferred_networks: Operator id string and MMModemAccessTechnology mask.
+		"""
+		raise NotImplementedError
+
+	@dbus_property(property_signature='b')
+	def active(self) -> bool:
+		"""Boolean indicating whether the SIM is currently active."""
+		raise NotImplementedError
+
 	@dbus_property('s')
 	def sim_identifier(self) -> str:
 		"""
@@ -56,6 +75,11 @@ class MMSimInterface(DbusInterfaceCommon, interface_name='org.freedesktop.ModemM
 		"""The IMSI of the SIM card, if any."""
 		raise NotImplementedError
 
+	@dbus_property(property_signature='s')
+	def eid(self) -> str:
+		"""The EID of the SIM card, if any."""
+		raise NotImplementedError
+
 	@dbus_property('s')
 	def operator_identifier(self) -> str:
 		raise NotImplementedError
@@ -63,4 +87,44 @@ class MMSimInterface(DbusInterfaceCommon, interface_name='org.freedesktop.ModemM
 	@dbus_property('s')
 	def operator_name(self) -> str:
 		"""The name of the network operator, as given by the SIM card, if known."""
+		raise NotImplementedError
+
+	@dbus_property(property_signature='as')
+	def emergency_numbers(self) -> List[str]:
+		"""List of emergency numbers programmed in the SIM card."""
+		raise NotImplementedError
+
+	@dbus_property(property_signature='a(su)')
+	def preferred_networks(self) -> List[Tuple[str, int]]:
+		"""
+		List of preferred networks with access technologies configured in the SIM card.
+
+		Each entry contains an operator id string ("MCCMNC") consisting of 5 or 6 digits,
+		and an MMModemAccessTechnology mask to store to SIM card if supported.
+		"""
+		raise NotImplementedError
+
+	@dbus_property(property_signature='ay')
+	def gid1(self) -> bytes:
+		"""Group identifier level 1."""
+		raise NotImplementedError
+
+	@dbus_property(property_signature='ay')
+	def gid2(self) -> bytes:
+		"""Group identifier level 2."""
+		raise NotImplementedError
+
+	@dbus_property(property_signature='u')
+	def sim_type(self) -> int:
+		"""Indicates whether the current primary SIM is a ESIM or a physical SIM, given as MMSimType value."""
+		raise NotImplementedError
+
+	@dbus_property(property_signature='u')
+	def esim_status(self) -> int:
+		"""If current SIM is ESIM then this indicates whether there is a profile or not, given as MMSimEsimStatus value."""
+		raise NotImplementedError
+
+	@dbus_property(property_signature='u')
+	def removability(self) -> int:
+		"""Indicates whether the current SIM is a removable SIM or not, given as a MMSimRemovability value."""
 		raise NotImplementedError

--- a/sdbus_block/modemmanager/objects.py
+++ b/sdbus_block/modemmanager/objects.py
@@ -5,7 +5,7 @@ from sdbus.sd_bus_internals import SdBus
 from .enums import MMCallDirection, MMCallState, MMCallStateReason
 from .interfaces_bearer import MMBearerInterface
 from .interfaces_call import MMCallInterface
-from .interfaces_modem import MMModemInterface, MMModemMessagingInterface, MMModemSimpleInterface, MMModemSingalInterface, MMModemsInterface, MMModemVoiceInterface
+from .interfaces_modem import MMModemInterface, MMModemMessagingInterface, MMModemSimpleInterface, MMModemSignalInterface, MMModemsInterface, MMModemVoiceInterface
 from .interfaces_root import MMInterface
 from .interfaces_sim import MMSimInterface
 from .interfaces_sms import MMSmsInterface
@@ -64,7 +64,7 @@ class MMModemMessaging(MMModemMessagingInterface):
 		self.delete(sms._remote_object_path)
 
 
-class MMModemSignal(MMModemSingalInterface):
+class MMModemSignal(MMModemSignalInterface):
 
 	def __init__(self, object_path: str, bus: Optional[SdBus] = None) -> None:
 		"""

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     license='LGPL-2.1-or-later',
-    packages=['sdbus_block.modemmanager'],
+    packages=['sdbus_async.modemmanager', 'sdbus_block.modemmanager'],
     python_requires='>=3.7',
     install_requires=[
         'sdbus>=0.8rc2',


### PR DESCRIPTION
Signals are only available in sdbus_async, so implementation of SMS reception requires a full sdbus_async.