### PR TITLE
Fix messaging.delete_sms function

### DIFF
--- a/sdbus_async/modemmanager/objects.py
+++ b/sdbus_async/modemmanager/objects.py
@@ -64,7 +64,7 @@ class MMModemMessaging(MMModemMessagingInterfaceAsync):
 
 	async def delete_sms(self, sms: MMSms) -> None:
 		"""Delete an SMS message."""
-		self.delete(sms._remote_object_path)
+		self.delete(sms._dbus.object_path)
 
 
 class MMModemSignal(MMModemSignalInterfaceAsync):

--- a/sdbus_block/modemmanager/objects.py
+++ b/sdbus_block/modemmanager/objects.py
@@ -61,7 +61,7 @@ class MMModemMessaging(MMModemMessagingInterface):
 
 	def delete_sms(self, sms: MMSms) -> None:
 		"""Delete an SMS message."""
-		self.delete(sms._remote_object_path)
+		self.delete(sms._sdbus.object_path)
 
 
 class MMModemSignal(MMModemSignalInterface):


### PR DESCRIPTION
Change to make messaging.delete_sms use the object_path from the _dbus object in preference to the none existent remote_object_path property