### PR TITLE
Fix simple.connect and add other properties offered

### DIFF
--- a/sdbus_block/modemmanager/__init__.py
+++ b/sdbus_block/modemmanager/__init__.py
@@ -9,8 +9,9 @@ from .interfaces_sim import MMSimInterface
 from .interfaces_sms import MMSmsInterface
 from .interfaces_3gpp import MMModem3gppInterface
 from .interfaces_simple import MMModemSimpleInterface
+from .interfaces_time import MMModemTimeInterface
 
-from .objects import MM, MMBearer, MMCall, MMModem, MMModems, MMModemMessaging, MMModemSignal, MMModemSimple, MMModemVoice, MMSim, MMSms, MMModem3gpp
+from .objects import MM, MMBearer, MMCall, MMModem, MMModems, MMModemMessaging, MMModemSignal, MMModemSimple, MMModemVoice, MMSim, MMSms, MMModem3gpp, MMModemTime
 
 __all__ = (
 	# .enums
@@ -37,8 +38,10 @@ __all__ = (
 	'MMSimInterface',
 	# .interfaces_sms
 	'MMSmsInterface',
-    # .MMModem3gppInterface
+	# .MMModem3gppInterface
 	'MMModem3gppInterface',
+	# .MMModemTimeInterface
+	'MMModemTimeInterface',
 	# .objects
 	'MM',
 	'MMModems',
@@ -52,4 +55,5 @@ __all__ = (
 	'MMBearer',
 	'MMCall',
 	'MMModem3gpp',
+	'MMModemTime',
 )

--- a/sdbus_block/modemmanager/__init__.py
+++ b/sdbus_block/modemmanager/__init__.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 from .enums import MMModemState, MMModemMode, MMModemPowerState, MMCallDirection, MMCallState, MMCallStateReason
 from .interfaces_bearer import MMBearerInterface
 from .interfaces_call import MMCallInterface
-from .interfaces_modem import MMModemInterface, MMModemMessagingInterface, MMModemSimpleInterface, MMModemSignalInterface, MMModemsInterface, MMModemVoiceInterface
+from .interfaces_modem import MMModemInterface, MMModemMessagingInterface, MMModemSignalInterface, MMModemsInterface, MMModemVoiceInterface
 from .interfaces_root import MMInterface
 from .interfaces_sim import MMSimInterface
 from .interfaces_sms import MMSmsInterface
-from .objects import MM, MMBearer, MMCall, MMModem, MMModems, MMModemMessaging, MMModemSignal, MMModemSimple, MMModemVoice, MMSim, MMSms
+from .interfaces_3gpp import MMModem3gppInterface
+from .interfaces_simple import MMModemSimpleInterface
+
+from .objects import MM, MMBearer, MMCall, MMModem, MMModems, MMModemMessaging, MMModemSignal, MMModemSimple, MMModemVoice, MMSim, MMSms, MMModem3gpp
 
 __all__ = (
 	# .enums
@@ -34,6 +37,8 @@ __all__ = (
 	'MMSimInterface',
 	# .interfaces_sms
 	'MMSmsInterface',
+    # .MMModem3gppInterface
+	'MMModem3gppInterface',
 	# .objects
 	'MM',
 	'MMModems',
@@ -46,4 +51,5 @@ __all__ = (
 	'MMSms',
 	'MMBearer',
 	'MMCall',
+	'MMModem3gpp',
 )

--- a/sdbus_block/modemmanager/interfaces_3gpp.py
+++ b/sdbus_block/modemmanager/interfaces_3gpp.py
@@ -1,0 +1,23 @@
+from typing import Any, Dict, List, Optional, Tuple
+
+from sdbus import DbusInterfaceCommon, DbusObjectManagerInterface, dbus_method, dbus_property
+
+
+class MMModem3gppInterface(DbusInterfaceCommon, interface_name="org.freedesktop.ModemManager1.Modem.Modem3gpp"):
+	"""Set initial EPS Bearer setting
+	List of properties to use when requesting the LTE attach procedure.
+
+	Updates the default settings to be used in the initial default EPS bearer when registering to the LTE network.
+
+	The allowed properties in this method are all the 3GPP-specific ones specified in the bearer properties.
+	i.e.: "apn", "ip-type", "allowed-auth", "user" and "password".
+	
+	param properties: Dictionary of properties needed initiate a connexion ex: {"apn": ("s", "yourAPN.isp"), "ip-type": ("s", "ipv4v6")}
+	"""
+	@dbus_method(input_signature="a{sv}")
+	def set_initial_eps_bearer_settings(
+		self,
+		settings: Dict[str, Tuple[str, Any]],
+	) -> None:
+		raise NotImplementedError
+

--- a/sdbus_block/modemmanager/interfaces_modem.py
+++ b/sdbus_block/modemmanager/interfaces_modem.py
@@ -169,6 +169,11 @@ class MMModemInterface(DbusInterfaceCommon, interface_name='org.freedesktop.Mode
 	def current_capabilities_text(self) -> Tuple[str]:
 		return tuple(MMModemCapability.names(self.current_capabilities))
 
+	@dbus_method(result_signature='aa{sv}')
+	def get_cell_info(self) -> List[Dict[str, Tuple[str, Any]]]:
+		raise NotImplementedError
+
+
 
 class MMModemMessagingInterface(DbusInterfaceCommon, interface_name='org.freedesktop.ModemManager1.Modem.Messaging'):
 	"""The Messaging interface handles sending SMS messages and notification of new incoming messages."""
@@ -201,83 +206,6 @@ class MMModemMessagingInterface(DbusInterfaceCommon, interface_name='org.freedes
 	@dbus_property(property_signature='u')
 	def default_storage(self) -> int:
 		"""A MMSmsStorage value, specifying the storage to be used when receiving or storing SMS."""
-		raise NotImplementedError
-
-
-class MMModemSimpleInterface(DbusInterfaceCommon, interface_name='org.freedesktop.ModemManager1.Modem.Simple'):
-
-	@dbus_method(input_signature='a{sv}', result_signature='o')
-	def connect(self, properties: str, bearer: Dict[str, Tuple[str, Any]]) -> str:
-		"""
-		Allowed key/value pairs in properties are:
-
-		"pin"
-			SIM-PIN unlock code, given as a string value (signature "s").
-		"operator-id"
-			ETSI MCC-MNC of a network to force registration with, given as a string value (signature "s").
-		"apn"
-			For GSM/UMTS and LTE devices the APN to use, given as a string value (signature "s").
-		"ip-type"
-			For GSM/UMTS and LTE devices the IP addressing type to use, given as a MMBearerIpFamily value (signature "u").
-		"allowed-auth"
-			The authentication method to use, given as a MMBearerAllowedAuth value (signature "u"). Optional in 3GPP.
-		"user"
-			User name (if any) required by the network, given as a string value (signature "s"). Optional in 3GPP.
-		"password"
-			Password (if any) required by the network, given as a string value (signature "s"). Optional in 3GPP.
-		"number"
-			For POTS devices the number to dial, given as a string value (signature "s").
-		"allow-roaming"
-			False to allow only connections to home networks, given as a boolean value (signature "b").
-		"rm-protocol"
-			For CDMA devices, the protocol of the Rm interface, given as a MMModemCdmaRmProtocol value (signature "u").
-
-		:param properties: Dictionary of properties needed to get the modem connected.
-		:returns: On successful connect, returns the object path of the connected packet data bearer used for the connection attempt.
-		"""
-		raise NotImplementedError
-
-	@dbus_method(input_signature='o')
-	def disconnect(self, bearer: str):
-		"""
-		data bearer, while if "/" (ie, no object given) this method will disconnect all active packet data bearers.
-		Disconnect an active packet data connection.
-		:param bearer: If given this method will disconnect the referenced packet
-		"""
-		raise NotImplementedError
-
-	@dbus_method(result_signature='a{sv}')
-	def get_status(self) -> Dict[str, Tuple[str, Any]]:
-		"""
-		Get the general modem status.
-
-		The predefined common properties returned are:
-
-		"state"
-			A MMModemState value specifying the overall state of the modem, given as an unsigned integer value (signature "u").
-		"signal-quality"
-			Signal quality value, given only when registered, as an unsigned integer value (signature "u").
-		"current-bands"
-			List of MMModemBand values, given only when registered, as a list of unsigned integer values (signature "au").
-		"access-technology"
-			A MMModemAccessTechnology value, given only when registered, as an unsigned integer value (signature "u").
-		"m3gpp-registration-state"
-			A MMModem3gppRegistrationState value specifying the state of the registration, given only when registered in a 3GPP network, as an unsigned integer value (signature "u").
-		"m3gpp-operator-code"
-			Operator MCC-MNC, given only when registered in a 3GPP network, as a string value (signature "s").
-		"m3gpp-operator-name"
-			Operator name, given only when registered in a 3GPP network, as a string value (signature "s").
-		"cdma-cdma1x-registration-state"
-			A MMModemCdmaRegistrationState value specifying the state of the registration, given only when registered in a CDMA1x network, as an unsigned integer value (signature "u").
-		"cdma-evdo-registration-state"
-			A MMModemCdmaRegistrationState value specifying the state of the registration, given only when registered in a EV-DO network, as an unsigned integer value (signature "u").
-		"cdma-sid"
-			The System Identifier of the serving network, if registered in a CDMA1x network and if known. Given as an unsigned integer value (signature "u").
-		"cdma-nid"
-			The Network Identifier of the serving network, if registered in a CDMA1x network and if known. Given as an unsigned integer value (signature "u").
-		
-		:returns: Dictionary of properties.
-		"""
 		raise NotImplementedError
 
 

--- a/sdbus_block/modemmanager/interfaces_simple.py
+++ b/sdbus_block/modemmanager/interfaces_simple.py
@@ -20,33 +20,33 @@ class MMModemSimpleInterface(
 	DbusInterfaceCommon,
 	interface_name="org.freedesktop.ModemManager1.Modem.Simple",
 ):
-		"""
-		Allowed key/value pairs in properties are:
+	"""
+	Allowed key/value pairs in properties are:
 
-		"pin"
-			SIM-PIN unlock code, given as a string value (signature "s").
-		"operator-id"
-			ETSI MCC-MNC of a network to force registration with, given as a string value (signature "s").
-		"apn"
-			For GSM/UMTS and LTE devices the APN to use, given as a string value (signature "s").
-		"ip-type"
-			For GSM/UMTS and LTE devices the IP addressing type to use, given as a MMBearerIpFamily value (signature "u").
-		"allowed-auth"
-			The authentication method to use, given as a MMBearerAllowedAuth value (signature "u"). Optional in 3GPP.
-		"user"
-			User name (if any) required by the network, given as a string value (signature "s"). Optional in 3GPP.
-		"password"
-			Password (if any) required by the network, given as a string value (signature "s"). Optional in 3GPP.
-		"number"
-			For POTS devices the number to dial, given as a string value (signature "s").
-		"allow-roaming"
-			False to allow only connections to home networks, given as a boolean value (signature "b").
-		"rm-protocol"
-			For CDMA devices, the protocol of the Rm interface, given as a MMModemCdmaRmProtocol value (signature "u").
+	"pin"
+		SIM-PIN unlock code, given as a string value (signature "s").
+	"operator-id"
+		ETSI MCC-MNC of a network to force registration with, given as a string value (signature "s").
+	"apn"
+		For GSM/UMTS and LTE devices the APN to use, given as a string value (signature "s").
+	"ip-type"
+		For GSM/UMTS and LTE devices the IP addressing type to use, given as a MMBearerIpFamily value (signature "u").
+	"allowed-auth"
+		The authentication method to use, given as a MMBearerAllowedAuth value (signature "u"). Optional in 3GPP.
+	"user"
+		User name (if any) required by the network, given as a string value (signature "s"). Optional in 3GPP.
+	"password"
+		Password (if any) required by the network, given as a string value (signature "s"). Optional in 3GPP.
+	"number"
+		For POTS devices the number to dial, given as a string value (signature "s").
+	"allow-roaming"
+		False to allow only connections to home networks, given as a boolean value (signature "b").
+	"rm-protocol"
+		For CDMA devices, the protocol of the Rm interface, given as a MMModemCdmaRmProtocol value (signature "u").
 
-		:param properties: Dictionary of properties needed to get the modem connected. ex: {"apn": ("s", "yourAPN.isp"), "ip-type": ("s", "ipv4v6")}
-		:returns: On successful connect, returns the object path of the connected packet data bearer used for the connection attempt.
-		"""
+	:param properties: Dictionary of properties needed to get the modem connected. ex: {"apn": ("s", "yourAPN.isp"), "ip-type": ("s", "ipv4v6")}
+	:returns: On successful connect, returns the object path of the connected packet data bearer used for the connection attempt.
+	"""
 	@dbus_method(
 		input_signature="a{sv}",
 		result_signature="o",

--- a/sdbus_block/modemmanager/interfaces_simple.py
+++ b/sdbus_block/modemmanager/interfaces_simple.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from sdbus import (
+	DbusDeprecatedFlag,
+	DbusInterfaceCommon,
+	DbusNoReplyFlag,
+	DbusPropertyConstFlag,
+	DbusPropertyEmitsChangeFlag,
+	DbusPropertyEmitsInvalidationFlag,
+	DbusPropertyExplicitFlag,
+	DbusUnprivilegedFlag,
+	dbus_method,
+	dbus_property,
+)
+
+
+class MMModemSimpleInterface(
+	DbusInterfaceCommon,
+	interface_name="org.freedesktop.ModemManager1.Modem.Simple",
+):
+		"""
+		Allowed key/value pairs in properties are:
+
+		"pin"
+			SIM-PIN unlock code, given as a string value (signature "s").
+		"operator-id"
+			ETSI MCC-MNC of a network to force registration with, given as a string value (signature "s").
+		"apn"
+			For GSM/UMTS and LTE devices the APN to use, given as a string value (signature "s").
+		"ip-type"
+			For GSM/UMTS and LTE devices the IP addressing type to use, given as a MMBearerIpFamily value (signature "u").
+		"allowed-auth"
+			The authentication method to use, given as a MMBearerAllowedAuth value (signature "u"). Optional in 3GPP.
+		"user"
+			User name (if any) required by the network, given as a string value (signature "s"). Optional in 3GPP.
+		"password"
+			Password (if any) required by the network, given as a string value (signature "s"). Optional in 3GPP.
+		"number"
+			For POTS devices the number to dial, given as a string value (signature "s").
+		"allow-roaming"
+			False to allow only connections to home networks, given as a boolean value (signature "b").
+		"rm-protocol"
+			For CDMA devices, the protocol of the Rm interface, given as a MMModemCdmaRmProtocol value (signature "u").
+
+		:param properties: Dictionary of properties needed to get the modem connected. ex: {"apn": ("s", "yourAPN.isp"), "ip-type": ("s", "ipv4v6")}
+		:returns: On successful connect, returns the object path of the connected packet data bearer used for the connection attempt.
+		"""
+	@dbus_method(
+		input_signature="a{sv}",
+		result_signature="o",
+		flags=DbusUnprivilegedFlag,
+	)
+	def connect(
+		self,
+		properties: Dict[str, Tuple[str, Any]],
+	) -> str:
+		raise NotImplementedError
+
+		"""
+		data bearer, while if "/" (ie, no object given) this method will disconnect all active packet data bearers.
+		Disconnect an active packet data connection.
+		:param bearer: If given this method will disconnect the referenced packet
+		"""
+	@dbus_method(
+		input_signature="o",
+		flags=DbusUnprivilegedFlag,
+	)
+	def disconnect(
+		self,
+		bearer: str,
+	) -> None:
+		raise NotImplementedError
+
+		"""
+		Get the general modem status.
+
+		The predefined common properties returned are:
+
+		"state"
+			A MMModemState value specifying the overall state of the modem, given as an unsigned integer value (signature "u").
+		"signal-quality"
+			Signal quality value, given only when registered, as an unsigned integer value (signature "u").
+		"current-bands"
+			List of MMModemBand values, given only when registered, as a list of unsigned integer values (signature "au").
+		"access-technology"
+			A MMModemAccessTechnology value, given only when registered, as an unsigned integer value (signature "u").
+		"m3gpp-registration-state"
+			A MMModem3gppRegistrationState value specifying the state of the registration, given only when registered in a 3GPP network, as an unsigned integer value (signature "u").
+		"m3gpp-operator-code"
+			Operator MCC-MNC, given only when registered in a 3GPP network, as a string value (signature "s").
+		"m3gpp-operator-name"
+			Operator name, given only when registered in a 3GPP network, as a string value (signature "s").
+		"cdma-cdma1x-registration-state"
+			A MMModemCdmaRegistrationState value specifying the state of the registration, given only when registered in a CDMA1x network, as an unsigned integer value (signature "u").
+		"cdma-evdo-registration-state"
+			A MMModemCdmaRegistrationState value specifying the state of the registration, given only when registered in a EV-DO network, as an unsigned integer value (signature "u").
+		"cdma-sid"
+			The System Identifier of the serving network, if registered in a CDMA1x network and if known. Given as an unsigned integer value (signature "u").
+		"cdma-nid"
+			The Network Identifier of the serving network, if registered in a CDMA1x network and if known. Given as an unsigned integer value (signature "u").
+		
+		:returns: Dictionary of properties.
+		"""
+	@dbus_method(
+		result_signature="a{sv}",
+		flags=DbusUnprivilegedFlag,
+	)
+	def get_status(
+		self,
+	) -> Dict[str, Tuple[str, Any]]:
+		raise NotImplementedError

--- a/sdbus_block/modemmanager/interfaces_time.py
+++ b/sdbus_block/modemmanager/interfaces_time.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from sdbus import (
+	DbusDeprecatedFlag,
+	DbusInterfaceCommon,
+	DbusNoReplyFlag,
+	DbusPropertyConstFlag,
+	DbusPropertyEmitsChangeFlag,
+	DbusPropertyEmitsInvalidationFlag,
+	DbusPropertyExplicitFlag,
+	DbusUnprivilegedFlag,
+	dbus_method,
+	dbus_property,
+)
+
+
+class MMModemTimeInterface(
+	DbusInterfaceCommon,
+	interface_name="org.freedesktop.ModemManager1.Modem.Time",
+):
+	"""
+	Get local network time
+
+	:returns: datetime string %Y-%m-%dT%H:%M:%S-%z ex.: '2025-01-22T11:42:37-05'
+	"""
+	@dbus_method(
+		result_signature="s",
+		flags=DbusUnprivilegedFlag,
+	)
+	def get_network_time(
+		self,
+	) -> str:
+		raise NotImplementedError
+
+	"""
+	Get local timezone.
+
+	:returns: à dict containing the offset represented in seconds ex.: {'offset': ('i', -300)}
+
+	"""
+	@dbus_property(
+		property_signature="a{sv}",
+		flags=DbusPropertyEmitsChangeFlag,
+	)
+	def network_timezone(self) -> Dict[str, Tuple[str, Any]]:
+		raise NotImplementedError

--- a/sdbus_block/modemmanager/objects.py
+++ b/sdbus_block/modemmanager/objects.py
@@ -5,10 +5,12 @@ from sdbus.sd_bus_internals import SdBus
 from .enums import MMCallDirection, MMCallState, MMCallStateReason
 from .interfaces_bearer import MMBearerInterface
 from .interfaces_call import MMCallInterface
-from .interfaces_modem import MMModemInterface, MMModemMessagingInterface, MMModemSimpleInterface, MMModemSignalInterface, MMModemsInterface, MMModemVoiceInterface
+from .interfaces_modem import MMModemInterface, MMModemMessagingInterface,  MMModemSignalInterface, MMModemsInterface, MMModemVoiceInterface
 from .interfaces_root import MMInterface
 from .interfaces_sim import MMSimInterface
 from .interfaces_sms import MMSmsInterface
+from .interfaces_3gpp import MMModem3gppInterface
+from .interfaces_simple import MMModemSimpleInterface
 
 MODEM_MANAGER_SERVICE_NAME = 'org.freedesktop.ModemManager1'
 
@@ -105,6 +107,7 @@ class MMModem(MMModemInterface):
 		self.simple = MMModemSimple(object_path=object_path, bus=bus)
 		self.signal = MMModemSignal(object_path=object_path, bus=bus)
 		self.voice = MMModemVoice(object_path=object_path, bus=bus)
+		self.modem3gpp = MMModem3gpp(object_path=object_path, bus=bus)
 		self.sim: Optional[MMSim] = None
 		self.bearers: List[MMBearer] = []
 
@@ -191,3 +194,8 @@ class MMCall(MMCallInterface):
 	def direction_text(self) -> str:
 		"""A MMCallDirection name, describing the direction of the call."""
 		return MMCallDirection(self.direction).name
+
+class MMModem3gpp(MMModem3gppInterface):
+
+	def __init__(self, object_path: str, bus: Optional[SdBus] = None) -> None:
+		super().__init__(MODEM_MANAGER_SERVICE_NAME, object_path, bus)

--- a/sdbus_block/modemmanager/objects.py
+++ b/sdbus_block/modemmanager/objects.py
@@ -11,6 +11,7 @@ from .interfaces_sim import MMSimInterface
 from .interfaces_sms import MMSmsInterface
 from .interfaces_3gpp import MMModem3gppInterface
 from .interfaces_simple import MMModemSimpleInterface
+from .interfaces_time import MMModemTimeInterface
 
 MODEM_MANAGER_SERVICE_NAME = 'org.freedesktop.ModemManager1'
 
@@ -108,6 +109,7 @@ class MMModem(MMModemInterface):
 		self.signal = MMModemSignal(object_path=object_path, bus=bus)
 		self.voice = MMModemVoice(object_path=object_path, bus=bus)
 		self.modem3gpp = MMModem3gpp(object_path=object_path, bus=bus)
+		self.time = MMModemTime(object_path=object_path, bus=bus)
 		self.sim: Optional[MMSim] = None
 		self.bearers: List[MMBearer] = []
 
@@ -196,6 +198,11 @@ class MMCall(MMCallInterface):
 		return MMCallDirection(self.direction).name
 
 class MMModem3gpp(MMModem3gppInterface):
+
+	def __init__(self, object_path: str, bus: Optional[SdBus] = None) -> None:
+		super().__init__(MODEM_MANAGER_SERVICE_NAME, object_path, bus)
+        
+class MMModemTime(MMModemTimeInterface):
 
 	def __init__(self, object_path: str, bus: Optional[SdBus] = None) -> None:
 		super().__init__(MODEM_MANAGER_SERVICE_NAME, object_path, bus)


### PR DESCRIPTION
Hello,

I've found a bug in MMModemSimple that prevent me to pass parameters to the connect() method.

I've added two properties:
 - simplified Interface of Modem3GPP
 - added get_cell_info (array of cell tower info in the neighborhood)  in the MMModem interface