### PR TITLE
pyproject.toml: fix sdbus-modemmanager intall path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ classifiers = [
 
 [tool.poetry]
 packages = [
-    { include = "modemmanager", from="sdbus_async", to="sdbus_async/modemmanager" },
-    { include = "modemmanager", from="sdbus_block", to="sdbus_block/modemmanager" },
+    { include = "modemmanager", from="sdbus_async", to="sdbus_async" },
+    { include = "modemmanager", from="sdbus_block", to="sdbus_block" },
 ]
 
 [build-system]


### PR DESCRIPTION
Since the switch to poetry in 1.0.3 [1] python-sdbus-modemmanager install step miss-behave (as reported by [2]).

The sdbus-modemmanager python module is intalled in a second "modemmanager" subdirectory:

  /lib/python3.14/site-packages/sdbus_block/modemmanager/modemmanager/

This break existing python script using:

  from sdbus_block.modemmanager import MMBearer

Fix tool.poetry install step by removing one "modemmanager".

[1] 0d8ae7217841ab1bc12282076f766f94415573f5
[2] https://github.com/zhanglongqi/python-sdbus-modemmanager/issues/24

Fixes:
https://gitlab.com/buildroot.org/buildroot/-/jobs/13904075359